### PR TITLE
Fix AF crash

### DIFF
--- a/app/src/main/java/com/eszdman/photoncamera/ui/camera/CameraFragment.java
+++ b/app/src/main/java/com/eszdman/photoncamera/ui/camera/CameraFragment.java
@@ -233,9 +233,10 @@ public class CameraFragment extends Fragment {
         if (cameraFragmentBinding != null && captureController != null) {
             View focusCircle = cameraFragmentBinding.layoutViewfinder.touchFocus;
             AutoFitTextureView textureView = cameraFragmentBinding.layoutViewfinder.texture;
-            Point size = new Point(textureView.getWidth(), textureView.getHeight());
-
-            mTouchFocus = TouchFocus.initialise(captureController, focusCircle, size);
+            textureView.post(() -> {
+                Point size = new Point(textureView.getWidth(), textureView.getHeight());
+                mTouchFocus = TouchFocus.initialise(captureController, focusCircle, size);
+            });
         }
     }
 


### PR DESCRIPTION
Previously, when initializing the TouchFocus, the TextureView wasn't yet measured, leading to a height and width of 0, which messed up focusing calculations.