### PR TITLE
NoiseModeler: Handle zeroed models

### DIFF
--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/render/NoiseModeler.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/render/NoiseModeler.java
@@ -18,7 +18,7 @@ public class NoiseModeler {
         baseModel = new Pair[3];
         computeModel = new Pair[3];
         //inModel = null;
-        if (inModel == null || inModel.length == 0 || (specificSettingSensor != null && specificSettingSensor.ModelerExists)) {
+        if (inModel == null || inModel.length == 0 || inModel[0].first == 0.0 || (specificSettingSensor != null && specificSettingSensor.ModelerExists)) {
             Pair<Double, Double> CustomGeneratorS;
             Pair<Double, Double> CustomGeneratorO;
             if(specificSettingSensor != null) {


### PR DESCRIPTION
On sensors without noise models in bin, inModel is pairs of 0.0 which
are not caught here. Additionally, if no specific model is added, there
are two changes that cause breakages on these sensors:

004851f4334a6ab1f45d4e84ea8594905d62bcc9 -- results in black jpeg output
without model
7294c96fe2a9248819626084ca3d8ccdda7d96ef -- results in white jpeg output
without model

Verified with this change and a sensor specific noise model (which with this change is not required for usage), my unfortunate sensor has working jpeg output on pcam again. In addition to OnePlus devices with this issue, this also is known to impact OV13B10 on Apollo.