### PR TITLE
specific/oneplus/waffle: add preferred resolution entries

### DIFF
--- a/app/src/main/assets/specific/sensors/oneplus/cph2573.txt
+++ b/app/src/main/assets/specific/sensors/oneplus/cph2573.txt
@@ -35,6 +35,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.05
 captureSharpeningIntense = 1.0
+preferredResolution = {4096, 3072}
 
 sensor_3
 NoiseModelA = { 5.742451019697843e-07,6.105980876415757e-07,3.146043228762669e-07,3.4805068152249336e-07 }
@@ -54,6 +55,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4000, 3000}
 
 sensor_4
 NoiseModelA = { 8.104479823018812e-07,5.830000973863143e-07,5.848095975826944e-07,7.037399417785644e-07 }
@@ -73,3 +75,4 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4608, 3456}

--- a/app/src/main/assets/specific/sensors/oneplus/cph2581.txt
+++ b/app/src/main/assets/specific/sensors/oneplus/cph2581.txt
@@ -35,6 +35,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.05
 captureSharpeningIntense = 1.0
+preferredResolution = {4096, 3072}
 
 sensor_3
 NoiseModelA = { 5.742451019697843e-07,6.105980876415757e-07,3.146043228762669e-07,3.4805068152249336e-07 }
@@ -54,6 +55,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4000, 3000}
 
 sensor_4
 NoiseModelA = { 8.104479823018812e-07,5.830000973863143e-07,5.848095975826944e-07,7.037399417785644e-07 }
@@ -73,3 +75,4 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4608, 3456}

--- a/app/src/main/assets/specific/sensors/oneplus/cph2583.txt
+++ b/app/src/main/assets/specific/sensors/oneplus/cph2583.txt
@@ -35,6 +35,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.05
 captureSharpeningIntense = 1.0
+preferredResolution = {4096, 3072}
 
 sensor_3
 NoiseModelA = { 5.742451019697843e-07,6.105980876415757e-07,3.146043228762669e-07,3.4805068152249336e-07 }
@@ -54,6 +55,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4000, 3000}
 
 sensor_4
 NoiseModelA = { 8.104479823018812e-07,5.830000973863143e-07,5.848095975826944e-07,7.037399417785644e-07 }
@@ -73,3 +75,4 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4608, 3456}

--- a/app/src/main/assets/specific/sensors/oneplus/op595dl1.txt
+++ b/app/src/main/assets/specific/sensors/oneplus/op595dl1.txt
@@ -35,6 +35,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.05
 captureSharpeningIntense = 1.0
+preferredResolution = {4096, 3072}
 
 sensor_3
 NoiseModelA = { 5.742451019697843e-07,6.105980876415757e-07,3.146043228762669e-07,3.4805068152249336e-07 }
@@ -54,6 +55,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4000, 3000}
 
 sensor_4
 NoiseModelA = { 8.104479823018812e-07,5.830000973863143e-07,5.848095975826944e-07,7.037399417785644e-07 }
@@ -73,3 +75,4 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4608, 3456}

--- a/app/src/main/assets/specific/sensors/oneplus/waffle.txt
+++ b/app/src/main/assets/specific/sensors/oneplus/waffle.txt
@@ -35,6 +35,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.05
 captureSharpeningIntense = 1.0
+preferredResolution = {4096, 3072}
 
 sensor_3
 NoiseModelA = { 5.742451019697843e-07,6.105980876415757e-07,3.146043228762669e-07,3.4805068152249336e-07 }
@@ -54,6 +55,7 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4000, 3000}
 
 sensor_4
 NoiseModelA = { 8.104479823018812e-07,5.830000973863143e-07,5.848095975826944e-07,7.037399417785644e-07 }
@@ -73,3 +75,4 @@ referenceIlluminant1 = 21
 referenceIlluminant2 = 17
 captureSharpeningS = 1.0
 captureSharpeningIntense = 1.0
+preferredResolution = {4608, 3456}


### PR DESCRIPTION
Fixes:
 - Correct pdaf on binned resolution on telephoto
 - Binned mode on main and UWA (would crash previously due to wrong res selected).