### PR TITLE
Update LTM and fusion exposure pipelines

### DIFF
--- a/app/src/main/assets/shaders/initial.glsl
+++ b/app/src/main/assets/shaders/initial.glsl
@@ -13,7 +13,6 @@ uniform sampler2D PostLut;
 //uniform float saturation0;
 //uniform float saturation;
 #define CCT 0
-//Color mat's
 uniform mat3 sensorToIntermediate; // Color transform from XYZ to a wide-gamut colorspace
 #if CCT != 1
 uniform mat3 intermediateToSRGB; // Color transform from wide-gamut colorspace to sRGB
@@ -56,7 +55,7 @@ out vec3 Output;
 #define SATURATIONRED 0.7
 #define EPS (0.0008)
 #define FUSIONGAIN 1.0
-#define FUSION 0
+#define FUSION 1
 #define luminocity(x) dot(x.rgb, vec3(0.299, 0.587, 0.114))
 #define MINP 1.0
 #define NOISEO 0.0
@@ -71,17 +70,30 @@ out vec3 Output;
 #define FUSIONNORM 64.0
 #define VIGNETTE 0.0
 #define LTMMIX 0.0
+#define FUSIONCAP 8.0
+#define FUSIONFLOOR 0.25
+#define LTMCONTRASTBOOST 1.0
+// Range gate for the guided-filter refit and strength of the affine refit
+// deviation. The gate must be wide enough that the 5x5 window retains
+// same-side statistics at an edge: if it is tightened past the point where
+// only the center tap survives, the affine fit degenerates (ws -> 1 tap,
+// a -> 0) and the output collapses to the raw 2x2-block-quantized map value,
+// which applies the map's gain step misaligned from the true image edge by
+// up to 2px - that is the sharp, blocky halo on branches. Edge rejection is
+// already handled by the minLuma erosion, the range-gated overshoot clamp
+// and the map-side darkCap, so this gate only needs to reject the bulk of
+// the far side, not annihilate it.
+#define LTMLUMASIGMA 0.12
+#define LTMREFIT 0.35
 #import coords
 #import interpolation
 #import gaussian
-
 
 vec3 postlookup(in vec3 textureColor) {
     textureColor = clamp(textureColor, 0.0, 1.0);
 
     //0.0 - 63.0
-    highp float blueColor = textureColor.b * (float(POSTLUTSIZE)-1.0); //63.0;
-
+    highp float blueColor = textureColor.b * (float(POSTLUTSIZE)-1.0); //63;
     highp vec2 quad1;
     quad1.y = floor(floor(blueColor) / POSTLUTSIZETILES);
     quad1.x = floor(blueColor) - (quad1.y * POSTLUTSIZETILES);
@@ -98,13 +110,12 @@ vec3 postlookup(in vec3 textureColor) {
     texPos2.x = (quad2.x / POSTLUTSIZETILES) + 0.5/(POSTLUTSIZE*POSTLUTSIZETILES) + ((1.0/(POSTLUTSIZETILES) - 1.0/(POSTLUTSIZE*POSTLUTSIZETILES)) * textureColor.r);
     texPos2.y = (quad2.y / POSTLUTSIZETILES) + 0.5/(POSTLUTSIZE*POSTLUTSIZETILES) + ((1.0/(POSTLUTSIZETILES) - 1.0/(POSTLUTSIZE*POSTLUTSIZETILES)) * textureColor.g);
 
-    //Tile 1
+    //Tile1
     highp vec3 newColor1 = texture(PostLut, texPos1).rgb;
-    //Tile 2
+    //Tile2
     highp vec3 newColor2 = texture(PostLut, texPos2).rgb;
 
-    highp vec3 newColor = (mix(newColor1, newColor2, fract(blueColor)));
-    return newColor;
+    return (mix(newColor1, newColor2, fract(blueColor)));
 }
 vec3 tricubiclookup(in vec3 xyzIn){
     float res = float(POSTLUTSIZE)-1.0;
@@ -114,26 +125,10 @@ vec3 tricubiclookup(in vec3 xyzIn){
     return postlookup((inv-.5) / res);
 }
 
-float gammaEncode(float x) {
-    //return 1.055 * sqrt(x+EPS) - 0.055;
-    return (GAMMAX1*x+GAMMAX2*x*x+GAMMAX3*x*x*x);
-}
-float gammaEncode0(float x) {
-return x <= 0.0031308f ? x * 12.92f : 1.055f * pow(x, 0.4166667f) - 0.055f;
-}
-
-float gammaEncode2(float x) {
-    //return 1.055 * sqrt(x+EPS) - 0.055;
-    return texture(GammaCurve,vec2(x - 1.0/1024.0,0.5)).r;
-}
-
-//Apply Gamma correction
-vec3 gammaCorrectPixel(vec3 x) {
-    //float br = (x.r+x.g+x.b)/3.0;
-    //x/=br;
-    //return x*(GAMMAX1*br+GAMMAX2*br*br+GAMMAX3*br*br*br);
-    return (GAMMAX1*x+GAMMAX2*x*x+GAMMAX3*x*x*x);
-}
+float gammaEncode(float x) { return (GAMMAX1*x+GAMMAX2*x*x+GAMMAX3*x*x*x); }
+float gammaEncode0(float x) { return x <= 0.0031308f ? x * 12.92f : 1.055f * pow(x, 0.4166667f) - 0.055f; }
+float gammaEncode2(float x) { return texture(GammaCurve,vec2(x - 1.0/1024.0,0.5)).r; }
+vec3 gammaCorrectPixel(vec3 x) { return (GAMMAX1*x+GAMMAX2*x*x+GAMMAX3*x*x*x); }
 
 vec3 gammaCorrectPixel2(vec3 rgb) {
     rgb.r = mix(gammaEncode(rgb.r),gammaEncode2(rgb.r),min(rgb.r*9.0,1.0));
@@ -165,136 +160,29 @@ vec3 lookup(in vec3 textureColor) {
 
     highp vec3 newColor1 = texture(LookupTable, texPos1).rgb;
     highp vec3 newColor2 = texture(LookupTable, texPos2).rgb;
-
-    highp vec3 newColor = (mix(newColor1, newColor2, fract(blueColor)));
-    return newColor;
+    return (mix(newColor1, newColor2, fract(blueColor)));
 }
 #define TONEMAP_GAMMA (1.5)
-float tonemapSin(float ch) {
-    return ch < 0.0001f
-    ? ch
-    : 0.5f - 0.5f * cos(pow(ch, 1.0/TONEMAP_GAMMA) * PI);
-}
-
-vec2 tonemapSin(vec2 ch) {
-    return vec2(tonemapSin(ch.x), tonemapSin(ch.y));
-}
-/*
-vec3 tonemap(vec3 rgb, float gain) {
-    vec3 sorted = rgb;
-
-    float tmp;
-    int permutation = 0;
-
-    // Sort the RGB channels by value
-    if (sorted.z < sorted.y) {
-        tmp = sorted.z;
-        sorted.z = sorted.y;
-        sorted.y = tmp;
-        permutation |= 1;
-    }
-    if (sorted.y < sorted.x) {
-        tmp = sorted.y;
-        sorted.y = sorted.x;
-        sorted.x = tmp;
-        permutation |= 2;
-    }
-    if (sorted.z < sorted.y) {
-        tmp = sorted.z;
-        sorted.z = sorted.y;
-        sorted.y = tmp;
-        permutation |= 4;
-    }
-
-    vec2 minmax;
-    minmax.x = sorted.x;
-    minmax.y = sorted.z;
-
-    // Apply tonemapping curve to min, max RGB channel values
-    //vec4 toneMapCoeffs = vec4(-0.7836f, 0.8469f, 0.943f, 0.0209f);
-    minmax = pow(minmax, vec2(3.f)) * toneMapCoeffs.x +
-    pow(minmax, vec2(2.f)) * toneMapCoeffs.y +
-    minmax * toneMapCoeffs.z +
-    toneMapCoeffs.w;
-    minmax *= gain;
-    //minmax.r = texture(TonemapTex,vec2(minmax.r,0.5f)).r;
-    //minmax.g = texture(TonemapTex,vec2(minmax.g,0.5f)).r;
-
-    //minmax = mix(minmax, minmaxsin, 0.9f);
-
-    // Rescale middle value
-    float newMid;
-    if (sorted.z == sorted.x) {
-        newMid = minmax.y;
-    } else {
-        float yprog = (sorted.y - sorted.x) / (sorted.z - sorted.x);
-        newMid = minmax.x + (minmax.y - minmax.x) * yprog;
-    }
-
-    vec3 finalRGB;
-    switch (permutation) {
-        case 0: // b >= g >= r
-        finalRGB.r = minmax.x;
-        finalRGB.g = newMid;
-        finalRGB.b = minmax.y;
-        break;
-        case 1: // g >= b >= r
-        finalRGB.r = minmax.x;
-        finalRGB.b = newMid;
-        finalRGB.g = minmax.y;
-        break;
-        case 2: // b >= r >= g
-        finalRGB.g = minmax.x;
-        finalRGB.r = newMid;
-        finalRGB.b = minmax.y;
-        break;
-        case 3: // g >= r >= b
-        finalRGB.b = minmax.x;
-        finalRGB.r = newMid;
-        finalRGB.g = minmax.y;
-        break;
-        case 6: // r >= b >= g
-        finalRGB.g = minmax.x;
-        finalRGB.b = newMid;
-        finalRGB.r = minmax.y;
-        break;
-        case 7: // r >= g >= b
-        finalRGB.b = minmax.x;
-        finalRGB.g = newMid;
-        finalRGB.r = minmax.y;
-        break;
-    }
-    return finalRGB;
-}*/
+float tonemapSin(float ch) { return ch < 0.0001f ? ch : 0.5f - 0.5f * cos(pow(ch, 1.0/TONEMAP_GAMMA) * PI); }
+vec2 tonemapSin(vec2 ch) { return vec2(tonemapSin(ch.x), tonemapSin(ch.y)); }
 
 vec3 tonemap(vec3 rgb, float gain) {
-    float r = rgb.r;
-    float g = rgb.g;
-    float b = rgb.b;
-
+    float r = rgb.r; float g = rgb.g; float b = rgb.b;
     float min_val = min(r, min(g, b));
     float max_val = max(r, max(g, b));
     float mid_val = dot(rgb, vec3(1.0)) - min_val - max_val;
-
     vec2 minmax_in = vec2(min_val, max_val);
     vec2 minmax = minmax_in * minmax_in * minmax_in * toneMapCoeffs.x +
         minmax_in * minmax_in * toneMapCoeffs.y +
-        minmax_in * toneMapCoeffs.z +
-        toneMapCoeffs.w;
+        minmax_in * toneMapCoeffs.z + toneMapCoeffs.w;
     minmax *= gain;
-
-    float new_min = minmax.x;
-    float new_max = minmax.y;
-
+    float new_min = minmax.x; float new_max = minmax.y;
     float denom = max_val - min_val;
     float yprog = (mid_val - min_val) / (denom + 1e-10);
     float new_mid = new_min + (new_max - new_min) * yprog;
-
-    // Branchless assignment using nested mix for each channel
     float new_r = mix(mix(new_mid, new_max, float(r == max_val)), new_min, float(r == min_val));
     float new_g = mix(mix(new_mid, new_max, float(g == max_val)), new_min, float(g == min_val));
     float new_b = mix(mix(new_mid, new_max, float(b == max_val)), new_min, float(b == min_val));
-
     return vec3(new_r, new_g, new_b);
 }
 
@@ -303,6 +191,7 @@ vec3 brightnessContrast(vec3 value, float brightness, float contrast)
 {
     return (value - 0.5) * contrast + 0.5 + brightness;
 }
+
 // Source: https://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 vec3 rgb2hsv(vec3 c) {
     vec4 K = vec4(0.f, -1.f / 3.f, 2.f / 3.f, -1.f);
@@ -311,6 +200,7 @@ vec3 rgb2hsv(vec3 c) {
     float d = q.x - min(q.w, q.y);
     return vec3(abs(q.z + (q.w - q.y) / (6.f * d + 1.0e-10)), d / (q.x + 1.0e-10), q.x);
 }
+
 vec3 hsv2rgb(vec3 c) {
     vec4 K = vec4(1., 2. / 3., 1. / 3., 3.);
     vec3 p = abs(fract(c.xxx + K.xyz) * 6. - K.www);
@@ -318,7 +208,7 @@ vec3 hsv2rgb(vec3 c) {
 }
 vec3 hsv2rgb_smooth( in vec3 c ) {
     vec3 rgb = clamp( abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0 );
-    rgb = rgb*rgb*(3.0-2.0*rgb); // cubic smoothing
+    rgb = rgb*rgb*(3.0-2.0*rgb);
     return c.z * mix( vec3(1.0), rgb, c.y);
 }
 const float eps = 0.0000001;
@@ -332,59 +222,27 @@ vec3 rgb2hsl( vec3 col ){
     float maxc = max( col.r, max(col.g, col.b) );
     vec3  mask = step(col.grr,col.rgb) * step(col.bbg,col.rgb);
     vec3 h = mask * (vec3(0.0,2.0,4.0) + (col.gbr-col.brg)/(maxc-minc + eps)) / 6.0;
-    return vec3( fract( 1.0 + h.x + h.y + h.z ),              // H
-    (maxc-minc)/(1.0-abs(minc+maxc-1.0) + eps),  // S
-    (minc+maxc)*0.5 );                           // L
+    return vec3( fract( 1.0 + h.x + h.y + h.z ), (maxc-minc)/(1.0-abs(minc+maxc-1.0) + eps), (minc+maxc)*0.5 );
 }
-
 float reinhard_mono(float v, float max_white) {
     float numerator = v * (float(1.0f) + (v / float(max_white * max_white)));
     return numerator / (float(1.0f) + v);
 }
-
 vec3 saturate(vec3 rgb, float sat2, float sat) {
-    float r = rgb.r;
-    float g = rgb.g;
-    float b = rgb.b;
-    float br = (r+g+b)/3.0;
+    float br = (rgb.r+rgb.g+rgb.b)/3.0;
     float dfsat = mix(sat2,sat,br*br);
     vec3 hsv = rgb2hsv(vec3(rgb.r,rgb.g,rgb.b));
-    /*if(hsv.g < 0.5-0.0){
-        hsv.g *= mix(1.0,dfsat,hsv.g/(0.5-0.0));
-    } else
-    if(hsv.g > 0.5+0.0){
-        hsv.g *= mix(dfsat,1.0,(0.7-hsv.g)/(0.5-0.0));
-    }
-    else
-    //hsv.g *= mix(dfsat,1.0,abs(hsv.g-0.5)/0.1);
-    hsv.g *= dfsat;*/
-    //hsv.g *= dfsat;
     hsv.g = reinhard_mono(hsv.g*dfsat, max(1.0,dfsat*0.7));
-    //hsv.g *= SATURATIONC+unscaledGaussian(abs(hsv.g),SATURATIONGAUSS)*(dfsat*1.07-1.0);
     rgb = hsv2rgb(hsv);
     rgb.r = mix((rgb.r+br)/2.0,rgb.r,SATURATIONRED);
     return rgb;
 }
-#define TONEMAPSWITCH (0.05)
-#define TONEMAPAMP (1.0)
-
-vec3 reinhard_extended(vec3 v, float max_white){
-    vec3 numerator = v * (vec3(1.0f) + (v / vec3(max_white * max_white)));
-    return numerator / (vec3(1.0f) + v);
-}
-
-vec3 reinhard_extended(vec3 v, vec3 max_white){
-    vec3 numerator = v * (vec3(1.0f) + (v / vec3(max_white * max_white)));
-    return numerator / (vec3(1.0f) + v);
-}
-float reinhard_extended(float v, float max_white){
-    float numerator = v * (float(1.0f) + (v / float(max_white * max_white)));
-    return numerator / (float(1.0f) + v);
-}
+vec3 reinhard_extended(vec3 v, float max_white){ vec3 n = v * (vec3(1.0f) + (v / vec3(max_white * max_white))); return n / (vec3(1.0f) + v); }
+vec3 reinhard_extended(vec3 v, vec3 max_white){ vec3 n = v * (vec3(1.0f) + (v / vec3(max_white * max_white))); return n / (vec3(1.0f) + v); }
+float reinhard_extended(float v, float max_white){ float n = v * (float(1.0f) + (v / float(max_white * max_white))); return n / (float(1.0f) + v); }
 
 vec3 applyColorSpace(vec3 pRGB,float tonemapGain, float gainsVal){
     vec3 neutralPoint = vec3(NEUTRALPOINT);
-    //pRGB = clamp(reinhard_extended(pRGB*tonemapGain,max(1.0,tonemapGain)), vec3(0.0), neutralPoint);
     #if CCT == 0
     mat3 corr = intermediateToSRGB;
     #endif
@@ -404,7 +262,6 @@ vec3 applyColorSpace(vec3 pRGB,float tonemapGain, float gainsVal){
     pRGB = corr*sensorToIntermediate*(pRGB*neutralPoint);
     vec3 pHSV = rgb2hsl(pRGB);
     #if USE_HSV == 1
-
     vec3 modHSV = texture(HSVMap, vec2(pHSV.y,pHSV.x)).rgb;
     pHSV.x += modHSV.x/2.0;
     pHSV.y *= modHSV.y;
@@ -413,130 +270,157 @@ vec3 applyColorSpace(vec3 pRGB,float tonemapGain, float gainsVal){
     pRGB = hsl2rgb(pHSV);
     #endif
     float br = (pRGB.r+pRGB.g+pRGB.b)/3.0;
-    //pRGB /= br;
-    //float vignetteFactor = mix(0.0,VIGNETTE,clamp(br*100.0 - 0.01,0.0,1.0));
     float noise = sqrt(NOISES + NOISEO + 1e-8);
-    //float vignetteFactor = smoothstep(0.0,min(noise, 0.1),br)*VIGNETTE;
     float vignetteFactor = (br*br/(br*br+noise*noise))*VIGNETTE;
     gainsVal = mix(float(1.0), gainsVal, 1.0);
-    //br = clamp(reinhard_extended(br*gainsVal,max(1.0,gainsVal)),0.0,1.0);
-    //br = clamp(reinhard_extended(br*tonemapGain,max(1.0,tonemapGain)),0.0,1.0);
-    pRGB = clamp(pRGB*mix(tonemapGain,1.0,LTMMIX), 0.0,1.0);
-    //pRGB = clamp(reinhard_extended(pRGB*tonemapGain,max(1.0,tonemapGain)),vec3(0.0),vec3(1.0));
-
+    // Apply the LTM gain directly to the single color-transformed signal. The
+    // earlier LP/HP split blurred the RAW InputBuffer but subtracted it from
+    // this TRANSFORMED signal, so the detail term contained a spurious color
+    // difference that was added back and slammed saturation. One consistent
+    // signal has no such defect.
+    vec3 pRGBBoosted = pRGB*mix(tonemapGain,1.0,LTMMIX);
+    pRGB = clamp(reinhard_extended(pRGBBoosted, max(1.0, tonemapGain)), 0.0, 1.0);
     pRGB = clamp(reinhard_extended(pRGB*gainsVal,max(1.0,gainsVal)),vec3(0.0),vec3(1.0));
-    //pRGB = clamp(pRGB*tonemapGain*gainsVal,vec3(0.0),vec3(1.0));
-
-    //ISO tint correction
-    //pRGB = mix(vec3(pRGB.r*0.99*(TINT2),pRGB.g*(TINT),pRGB.b*1.025*(TINT2)),pRGB,clamp(br*10.0,0.0,1.0));
-
-    //pRGB = saturate(pRGB,br);
-
     pRGB = gammaCorrectPixel2(pRGB);
     pRGB = tonemap(pRGB, mix(1.0,tonemapGain,LTMMIX));
-    pRGB = mix(pRGB*pRGB*pRGB*TONEMAPX3 + pRGB*pRGB*TONEMAPX2 + pRGB*TONEMAPX1,pRGB,min(pRGB*0.8+0.55,1.0));
-
+    pRGB = mix(pRGB*pRGB*pRGB*TONEMAPX3 + pRGB*pRGB*TONEMAPX2 + pRGB*TONEMAPX1, pRGB, min(pRGB*0.8+0.55,1.0));
     return pRGB;
 }
 
-float getGain(vec2 coordsShift){
-    vec2 fusionSize = vec2(textureSize(FusionMap, 0));
-    vec2 inputSize = vec2(textureSize(InputBuffer, 0));
-    vec2 baseCoord = (gl_FragCoord.xy + coordsShift) / inputSize;
-    float ingain = texture(FusionMap, baseCoord).r;
-    //float ingain = texelFetch(FusionMap, xy, 0).r;
-    /*if(ingain > 0.0){
-        ingain = 1.0/ingain;
-    } else ingain = -ingain;*/
-    return ingain*FUSIONGAIN;
+// FusionMap carries the bounded fused/base LTM gain ratio in .r, notch-
+// filtered edge-aware in fusionmap.glsl so it contains no texel-scale pattern.
+// getGain() samples it once per 2x2 output block, at the block center, so all
+// four pixels in the block share one gain prior and no even/odd interpolation
+// phase can paint a 2px grid on tonal transitions. The UV is normalized
+// against the full-res input size so half-res texel k covers exactly the
+// output block [2k, 2k+2).
+float getGain(ivec2 centerPos){
+    ivec2 inputSize = textureSize(InputBuffer, 0);
+    ivec2 blockBase = (centerPos / 2) * 2;
+    ivec2 blockCenter = blockBase + ivec2(1, 1);
+    vec2 uv = vec2(blockCenter) / vec2(inputSize);
+    return texture(FusionMap, uv).r * FUSIONGAIN;
 }
-float getLm(ivec2 coordsShift){
-    vec3 inrgb = texelFetch(InputBuffer, coordsShift, 0).rgb;
-    return inrgb.r+inrgb.g+inrgb.b;
+ivec2 clampInputPos(ivec2 pos, ivec2 inputSize) {
+    return clamp(pos, ivec2(0), inputSize - ivec2(1));
 }
-
-float convSin(float x){
-    return 0.5 + 0.5*sin((2.0*x-1.0) * PI/2.0);
-}
-
-vec3 contrastSin(vec3 value, float contrast)
-{
-    vec3 contr = vec3(convSin(value.r),convSin(value.g),convSin(value.b));
-    return mix(value,contr,contrast);
-}
-
-float aces(float x) {
-    const float a = 2.51;
-    const float b = 0.03;
-    const float c = 2.43;
-    const float d = 0.59;
-    const float e = 0.14;
-    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
-}
+float convSin(float x){ return 0.5 + 0.5*sin((2.0*x-1.0) * PI/2.0); }
+vec3 contrastSin(vec3 value, float contrast){ vec3 contr = vec3(convSin(value.r),convSin(value.g),convSin(value.b)); return mix(value,contr,contrast); }
+float aces(float x) { const float a=2.51,b=0.03,c=2.43,d=0.59,e=0.14; return clamp((x*(a*x+b))/(x*(c*x+d)+e),0.0,1.0); }
 
 void main() {
     ivec2 xy = ivec2(gl_FragCoord.xy);
     xy = mirrorCoords(xy,activeSize);
     vec3 sRGB = texelFetch(InputBuffer, xy, 0).rgb;
-    vec3 t;
-    //float tonemapGain = textureBicubic(FusionMap, vec2(gl_FragCoord.xy)/vec2(textureSize(InputBuffer, 0))).r*50.0;
-
     float tonemapGain = 1.f;
     #if FUSION == 1
-    // Guided upsampling with Gaussian-weighted linear model
-    //float momentX = 0.0, momentY = 0.0, momentX2 = 0.0, momentXY = 0.0;
-    vec4 moments = vec4(0.0);
-    const float sigma = 1.2;
+    // Edge-aware full-res application of the low-res gain map (guided filter).
+    //
+    // The map is sampled once per 2x2 output block (getGain above), so the
+    // gain field carries no even/odd interpolation phase. A local affine gain
+    // model gain = a*luma + b (He et al.) is then re-fit against full-res luma
+    // in a 5x5 window. The window average washes out any residual pyramid
+    // phase ripple left in the map (the grid on gradients), while the range
+    // gate keeps the model on one side of a tonal edge (no halo). Each tap
+    // reads the map at its own block center, so the windowed moments still see
+    // the map's spatial variation without alternating gain phase between
+    // even/odd pixels.
+    float momentX = 0.0, momentY = 0.0, momentX2 = 0.0, momentXY = 0.0;
+    float ws = 0.0;
+    float localMinGain = FUSIONCAP;
+    float localMaxGain = FUSIONFLOOR;
+    const float sigma = 2.0;
     const float sigmaSq2 = 2.0 * sigma * sigma;
+    const float lumaSigma = LTMLUMASIGMA;
+    const float lumaSigmaSq2 = 2.0 * lumaSigma * lumaSigma;
+    ivec2 inputSize = textureSize(InputBuffer, 0);
+    float centerLightness = luminocity(sRGB);
+    // Darkest luma in the window. Drives the gain ceiling so the shadow-lift
+    // release is eroded 2px into bright regions adjacent to dark content:
+    // no pixel near a dark object can lift, so no release ring can form.
+    float minLuma = centerLightness;
     for (int i = -2; i <= 2; i++) {
         for (int j = -2; j <= 2; j++) {
-            // Average lightness over 2x2 block to match FusionMap resolution
-            vec2 offset = vec2(float(i*2), float(j*2));
-            float lightness = dot(texelFetch(InputBuffer, xy + ivec2(i, j), 0).rgb, vec3(1.0/3.0));
-            float gain = texelFetch(FusionMap, (xy + ivec2(i, j))/2, 0).r;//getGain(offset);
-
-            //momentX += lightness;
-            //momentY += gain;
-            //momentX2 += lightness * lightness;
-            //momentXY += lightness * gain;
-            moments += vec4(lightness, gain, lightness * lightness, lightness * gain);
+            float lightness = luminocity(texelFetch(InputBuffer,
+                                                    clampInputPos(xy + ivec2(i, j), inputSize),
+                                                    0).rgb);
+            minLuma = min(minLuma, lightness);
+            float spatialWeight = exp(-float(i*i + j*j) / sigmaSq2);
+            // Block-aligned map sample: every tap inside the same 2x2 block
+            // reads the same texel, so the moments carry no even/odd phase.
+            float gain = getGain(xy + ivec2(i, j));
+            float lumaDelta = lightness - centerLightness;
+            float rangeWeight = exp(-(lumaDelta * lumaDelta) / lumaSigmaSq2);
+            // The overshoot clamp must only see gains from THIS side of a
+            // tonal edge. Min/max over all taps admits the far side's gains
+            // into the window, and the refit is then allowed to overshoot
+            // toward them at the boundary - that overshoot is the halo.
+            if (rangeWeight > 0.5) {
+                localMinGain = min(localMinGain, gain);
+                localMaxGain = max(localMaxGain, gain);
+            }
+            float w = spatialWeight * rangeWeight;
+            momentX += lightness * w;
+            momentY += gain * w;
+            momentX2 += lightness * lightness * w;
+            momentXY += lightness * gain * w;
+            ws += w;
         }
     }
-    float invWs = 1.0 / 25.0;
-    moments *= invWs; // Normalize by the number of samples (5x5)
-    float meanX = moments.x;
-    float meanY = moments.y;
-    float covXY = moments.w - meanX * meanY;
-    float varX = moments.z - meanX * meanX;
-    // Handle zero variance case with epsilon for stability
-    float a = covXY / (max(varX, 0.0) + 3e-04);
-    vec2 gainAB = vec2(a, meanY - a * meanX);
-    //vec2 gainAB = texture(FusionMap, vec2(gl_FragCoord.xy)/vec2(textureSize(InputBuffer, 0))).rg * FUSIONGAIN;
-    tonemapGain =  gainAB.r * ((luminocity(sRGB))) + gainAB.g;
-    //tonemapGain = mix(1.0,tonemapGain,texture(IntenseCurve, vec2(dot(sRGB.rgb,vec3(1.0/3.0)),0.0)).r);
-    //tonemapGain = max(tonemapGain, 0.5);
+    // Degenerate-window guard: at a hard edge the range gate can reject every
+    // tap but the center one, leaving ws ~ 1 tap's weight and a variance
+    // of zero. The affine fit then produces a meaningless a and an unstable
+    // mean; fall back to the raw block gain instead.
+    if (ws < 0.01) {
+        tonemapGain = getGain(xy);
+        localMinGain = min(localMinGain, tonemapGain);
+        localMaxGain = max(localMaxGain, tonemapGain);
+    } else {
+        float invWs = 1.0 / ws;
+        float meanX = momentX * invWs;
+        float meanY = momentY * invWs;
+        float covXY = momentXY * invWs - meanX * meanY;
+        float varX = momentX2 * invWs - meanX * meanX;
+        float guideVariance = max(varX, 0.0);
+        float varianceRegularizer = 0.0001 + 0.001 * max(meanX, 0.01);
+        float a = clamp(covXY / (guideVariance + varianceRegularizer), -FUSIONCAP, FUSIONCAP);
+        float guidedGain = meanY + (a * (centerLightness - meanX)) * LTMREFIT;
+        tonemapGain = guidedGain;
+    }
+    // The affine refit must not overshoot the same-side map values actually
+    // present in this window: that is exactly how over/under-shoots (halos)
+    // appear.
+    tonemapGain = clamp(tonemapGain, localMinGain, localMaxGain);
+    // Two-sided gain ceiling.
+    //
+    // Dark side (minLuma): driven by the DARKEST luma in the window, not the
+    // center pixel. A center-luma gate releases the shadow cap on
+    // anti-aliased edge pixels (luma 0.15-0.45) while the adjacent dark
+    // object stays capped, and that partial-release ring is the bright halo
+    // around dark objects (TV on a wall, branches against sky). The window
+    // minimum erodes the release 2px into the bright side, so the lift can
+    // only engage in regions that contain no dark content at all. The
+    // release band starts higher (0.20) and ends higher (0.55) so dark,
+    // noisy shadows are not lifted into visibility.
+    float darkCap = mix(FUSIONGAIN, FUSIONCAP,
+            smoothstep(0.20, 0.55, minLuma));
+    // Bright side (centerLightness): wherever the pixel itself is already
+    // bright, fused/base > 1 is by definition cross-edge contamination from
+    // a darker neighbor, never a legitimate lift - bright regions only ever
+    // need compression. Capping lift at FUSIONGAIN there removes the wide,
+    // soft glow that the erosion cannot reach. Gains below FUSIONGAIN pass
+    // both ceilings untouched.
+    float brightCap = mix(FUSIONCAP, FUSIONGAIN,
+            smoothstep(0.40, 0.65, centerLightness));
+    tonemapGain = min(tonemapGain, min(darkCap, brightCap));
+    tonemapGain = clamp(tonemapGain, 0.25, FUSIONCAP);
     #endif
-    float br = (sRGB.r+sRGB.g+sRGB.b)/3.0;
     vec4 gains = textureBicubicHardware(GainMap, vec2(xy)/vec2(textureSize(InputBuffer, 0)));
     gains.rgb = vec3(gains.r,(gains.g+gains.b)/2.0,gains.a);
     float gainsVal = dot(gains.rgb,vec3(1.0/3.0));
-    sRGB = applyColorSpace(sRGB,tonemapGain, gainsVal);
-    //sRGB = vec3(tonemapGain);
-    #if LUT == 1
-    //sRGB = lookup(sRGB);
-    #endif
-    //Rip Shadowing applied
-    //br = (clamp(br-0.0008,0.0,0.007)*(1.0/0.007));
-    //br*= (clamp(3.0-sRGB.r+sRGB.g+sRGB.b,0.0,0.006)*(1.0/0.006));
-
-
-    //float sat2 = SATURATION2;
-    //sat2*=br;
+    sRGB = applyColorSpace(sRGB, tonemapGain, gainsVal);
     sRGB = saturate(sRGB,SATURATION2,SATURATION);
-    sRGB = contrastSin(sRGB,mix(CONTRAST+SHADOWS, CONTRAST, luminocity(sRGB)));
-    //float noiseO = (NOISEO*NOISEO)*0.25;
-    //noiseO = min(noiseO,0.25);
-    //Output = clamp((sRGB-noiseO)/(vec3(1.0)-noiseO),0.0,1.0);
+    sRGB = contrastSin(sRGB,mix(CONTRAST+SHADOWS, CONTRAST, luminocity(sRGB)) * LTMCONTRASTBOOST);
     Output = clamp(sRGB,0.0,1.0);
     #if POSTLUT == 1
         Output = postlookup(Output);

--- a/app/src/main/assets/shaders/ltm/exposebayer2.glsl
+++ b/app/src/main/assets/shaders/ltm/exposebayer2.glsl
@@ -97,7 +97,9 @@ void main() {
     inp.a = texelFetch(InputBuffer, xyCenter+ivec2(1,1), 0).r;
     vec4 gains = textureBicubicHardware(GainMap, vec2(xyCenter)/vec2(textureSize(InputBuffer, 0)));
     inp *= (gains.r + gains.g + gains.b + gains.a) / 4.0;
-    //inp /= neutral.rggb;
+    // Normalize the four Bayer planes before calculating exposure weights.
+    // Without this, white-point differences are interpreted as brightness.
+    inp /= max(neutral.rggb, vec4(1e-6));
     inp = clamp(inp, vec4(0.0), vec4(1.0));
     //inp = clamp(inp,vec4(0.0001),vec3(NEUTRALPOINT).rggb)/vec3(NEUTRALPOINT).rggb;
 
@@ -116,16 +118,16 @@ void main() {
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.g = clamp((br),0.0,1.0);
+    result.g = clamp(br,0.0,highLim);
     v3 = brIn(inp,mix(STRHIGH,1.0,0.5));
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.b = clamp((br),0.0,1.0);
+    result.b = clamp(br,0.0,highLim);
     v3 = brIn(inp,mix(STRHIGH,1.0,0.25));
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.a = clamp((br),0.0,1.0);
+    result.a = clamp(br,0.0,highLim);
     result /= 4.0;
 }

--- a/app/src/main/assets/shaders/ltm/fusionbayer.glsl
+++ b/app/src/main/assets/shaders/ltm/fusionbayer.glsl
@@ -21,10 +21,15 @@ out vec4 result;
 #import gaussian
 #import interpolation
 float laplace(sampler2D tex, vec4 mid, ivec2 xyCenter) {
-    vec4 left = texelFetch(tex, xyCenter - ivec2(1, 0), 0),
-    right = texelFetch(tex, xyCenter + ivec2(1, 0), 0),
-    top = texelFetch(tex, xyCenter - ivec2(0, 1), 0),
-    bottom = texelFetch(tex, xyCenter + ivec2(0, 1), 0);
+    ivec2 size = textureSize(tex, 0);
+    ivec2 leftPos = clamp(xyCenter - ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 rightPos = clamp(xyCenter + ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 topPos = clamp(xyCenter - ivec2(0, 1), ivec2(0), size - ivec2(1));
+    ivec2 bottomPos = clamp(xyCenter + ivec2(0, 1), ivec2(0), size - ivec2(1));
+    vec4 left = texelFetch(tex, leftPos, 0),
+    right = texelFetch(tex, rightPos, 0),
+    top = texelFetch(tex, topPos, 0),
+    bottom = texelFetch(tex, bottomPos, 0);
 
     return distance(4.f * mid, left + right + top + bottom);
 }

--- a/app/src/main/assets/shaders/ltm/fusionbayer2.glsl
+++ b/app/src/main/assets/shaders/ltm/fusionbayer2.glsl
@@ -10,7 +10,10 @@ uniform sampler2D normalExpo;
 uniform sampler2D normalExpoDiff;
 
 uniform int level;
-uniform ivec2 upscaleIn;
+// Reciprocal of the output dimensions, computed on the CPU as 1.0/size.
+// Multiplying by the precomputed reciprocal keeps full precision and avoids
+// the (slower, less precise) per-fragment GPU division.
+uniform vec2 upscaleIn;
 uniform float gauss;
 uniform float target;
 //#define TARGET 0.0
@@ -21,34 +24,63 @@ out float result;
 #import gaussian
 #import interpolation
 float laplace(sampler2D tex, float mid, ivec2 xyCenter) {
-    float left = texelFetch(tex, xyCenter - ivec2(1, 0), 0).r,
-    right = texelFetch(tex, xyCenter + ivec2(1, 0), 0).r,
-    top = texelFetch(tex, xyCenter - ivec2(0, 1), 0).r,
-    bottom = texelFetch(tex, xyCenter + ivec2(0, 1), 0).r;
+    ivec2 size = textureSize(tex, 0);
+    ivec2 leftPos = clamp(xyCenter - ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 rightPos = clamp(xyCenter + ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 topPos = clamp(xyCenter - ivec2(0, 1), ivec2(0), size - ivec2(1));
+    ivec2 bottomPos = clamp(xyCenter + ivec2(0, 1), ivec2(0), size - ivec2(1));
+    float left = texelFetch(tex, leftPos, 0).r,
+    right = texelFetch(tex, rightPos, 0).r,
+    top = texelFetch(tex, topPos, 0).r,
+    bottom = texelFetch(tex, bottomPos, 0).r;
 
     return distance(4. * mid, (left + right + top + bottom)*NORM);
 }
 float laplace2(sampler2D tex, float mid, ivec2 xyCenter) {
-    float left = texelFetch(tex, xyCenter - ivec2(1, 0), 0).b,
-    right = texelFetch(tex, xyCenter + ivec2(1, 0), 0).b,
-    top = texelFetch(tex, xyCenter - ivec2(0, 1), 0).b,
-    bottom = texelFetch(tex, xyCenter + ivec2(0, 1), 0).b;
+    ivec2 size = textureSize(tex, 0);
+    ivec2 leftPos = clamp(xyCenter - ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 rightPos = clamp(xyCenter + ivec2(1, 0), ivec2(0), size - ivec2(1));
+    ivec2 topPos = clamp(xyCenter - ivec2(0, 1), ivec2(0), size - ivec2(1));
+    ivec2 bottomPos = clamp(xyCenter + ivec2(0, 1), ivec2(0), size - ivec2(1));
+    float left = texelFetch(tex, leftPos, 0).b,
+    right = texelFetch(tex, rightPos, 0).b,
+    top = texelFetch(tex, topPos, 0).b,
+    bottom = texelFetch(tex, bottomPos, 0).b;
 
     return distance(4. * mid, (left + right + top + bottom)*NORM);
+}
+
+// 3x3 binomial [1,2,1]^2/16 pre-filter on the Laplacian detail: exact null at
+// the one-texel even/odd (Nyquist) phase pattern the pyramid upsampling bakes
+// into the detail, applied where the detail is read for blending.
+vec4 fetchDiffSmooth(sampler2D tex, ivec2 xy) {
+    ivec2 size = textureSize(tex, 0);
+    vec4 acc = vec4(0.0);
+    float ws = 0.0;
+    for (int i = -1; i <= 1; i++) {
+        for (int j = -1; j <= 1; j++) {
+            ivec2 pos = clamp(xy + ivec2(i, j), ivec2(0), size - 1);
+            float w = float((i == 0) ? 2 : 1) * float((j == 0) ? 2 : 1);
+            acc += texelFetch(tex, pos, 0) * w;
+            ws += w;
+        }
+    }
+    return acc / ws;
 }
 
 void main() {
     ivec2 xyCenter = ivec2(gl_FragCoord.xy);
 
     // If this is the lowest layer, start with zero.
-    //if(useUpsampled == 2) mpy = 2.0;
     float base = (useUpsampled)
-    //? texelFetch(upsampled, xyCenter, 0).xyz
-    ? textureBicubicHardware(upsampled, (vec2(gl_FragCoord.xy))/(vec2(upscaleIn))).r
+    ? texture(upsampled,
+            vec2(gl_FragCoord.xy) * upscaleIn).r
     : float(0.0);
-    // How are we going to blend these two?
-    vec2 normal = texelFetch(normalExpoDiff, xyCenter, 0).rg;
-    vec2 high = texelFetch(normalExpoDiff, xyCenter, 0).ba;
+    // How are we going to blend these two? The detail is pre-filtered to strip
+    // the even/odd phase pattern before it is blended and added.
+    vec4 diffS = fetchDiffSmooth(normalExpoDiff, xyCenter);
+    vec2 normal = diffS.rg;
+    vec2 high = diffS.ba;
 
     // To know that, look at multiple factors.
     vec2 midNormal = texelFetch(normalExpo, xyCenter, 0).rg*NORM;
@@ -58,11 +90,8 @@ void main() {
     float highWeight = 1.;
 
     // Factor 1: Well-exposedness.
-
     float midNormalToAvg = (pdf((midNormal.r - target)/gauss));
     float midHighToAvg = (pdf((midHigh.r - target)/gauss));
-    //midNormalToAvg *= midNormalToAvg;
-    //midHighToAvg *= midHighToAvg;
 
     normalWeight *= midNormalToAvg;
     highWeight *= midHighToAvg;
@@ -70,22 +99,11 @@ void main() {
     // Factor 2: Contrast.
     float laplaceNormal = laplace(normalExpo, midNormal.r, xyCenter);
     float laplaceHigh = laplace2(normalExpo, midHigh.r, xyCenter);
-    //laplaceNormal *= laplaceNormal;
-    //laplaceHigh *= laplaceHigh;
 
     normalWeight *= (laplaceNormal + 0.001);
     highWeight *= (laplaceHigh + 0.001);
 
-    // Factor 3: Saturation.
-    /*float normalStddev = midNormal.g;
-    float highStddev = midHigh.g;
-
-    normalWeight *= normalStddev;
-    highWeight *= highStddev;*/
-
     float blend = highWeight / (normalWeight + highWeight); // [0, 1]
-    //result = base + mix(normal.r, high.r, blend*blend)*(max(1.0, 1.4 - 0.4*(float(level)/float(MAXLEVEL))));
-    //result = base + mix(normal.r, high.r, blend*blend)*(max(1.0, 1.1 - 0.1*(float(level)/float(MAXLEVEL))));
     result = base + mix(normal.r, high.r, blend);
     result = clamp(result,0.0,1.0);
     //if(level == 0){

--- a/app/src/main/assets/shaders/ltm/fusionbayer3.glsl
+++ b/app/src/main/assets/shaders/ltm/fusionbayer3.glsl
@@ -10,6 +10,9 @@ uniform sampler2D normalExpo;
 uniform sampler2D normalExpoDiff;
 
 uniform int level;
+// Reciprocal of the output dimensions, computed on the CPU as 1.0/size.
+// Multiplying by the precomputed reciprocal keeps full precision and avoids
+// the (slower, less precise) per-fragment GPU division.
 uniform vec2 upscaleIn;
 uniform float gauss;
 uniform float target;
@@ -25,20 +28,47 @@ out float result;
 #import interpolation
 
 vec4 laplace(sampler2D tex, vec4 mid, ivec2 xyCenter) {
+        // textureSize is loop-invariant: hoist it out of the 9-tap loop.
+        ivec2 size = textureSize(tex, 0);
         vec4 outp = mid*9.0;
         for (int i = -1; i <= 1; i++) {
             for (int j = -1; j <= 1; j++) {
-                outp -= texelFetch(tex, xyCenter + ivec2(i, j), 0);
+                ivec2 pos = clamp(xyCenter + ivec2(i, j), ivec2(0), size - ivec2(1));
+                outp -= texelFetch(tex, pos, 0);
             }
         }
         return abs(outp);
 }
 
+// 3x3 binomial [1,2,1]^2/16 pre-filter on the Laplacian detail. The pyramid's
+// upsampling bakes a one-texel even/odd (Nyquist) phase pattern into the
+// detail; this kernel has an exact spectral null at Nyquist and removes it at
+// the point where the detail is added, instead of letting it ride into the
+// fused result. It is a plain low-pass (not a filter swap), so it preserves
+// the detail's local mean and does not disturb the analysis/synthesis match.
+vec4 fetchDiffSmooth(sampler2D tex, ivec2 xy) {
+    ivec2 size = textureSize(tex, 0);
+    vec4 acc = vec4(0.0);
+    float ws = 0.0;
+    for (int i = -1; i <= 1; i++) {
+        for (int j = -1; j <= 1; j++) {
+            ivec2 pos = clamp(xy + ivec2(i, j), ivec2(0), size - 1);
+            float w = float((i == 0) ? 2 : 1) * float((j == 0) ? 2 : 1);
+            acc += texelFetch(tex, pos, 0) * w;
+            ws += w;
+        }
+    }
+    return acc / ws;
+}
+
 void main() {
     ivec2 xyCenter = ivec2(gl_FragCoord.xy);
-    // If this is the lowest layer, start with zero.
+    // If this is the lowest layer, start with zero. The +0.5 centers the
+    // coordinate on the output texel so the bilinear fetch is not biased
+    // half a texel toward the origin at every pyramid level.
+    vec2 upCoord = (vec2(gl_FragCoord.xy) + vec2(0.5)) * upscaleIn;
     float base = (useUpsampled)
-    ? texture(upsampled, (vec2(gl_FragCoord.xy))*(vec2(upscaleIn))).r
+    ? texture(upsampled, upCoord).r
     : float(0.0);
 
     // To know that, look at multiple factors.
@@ -55,10 +85,32 @@ void main() {
     weights *= laplaceVal + LAPLACEMIN;
 
     weights *= weights;
-    // How are we going to blend these two?
-    vec4 expoDiff = texelFetch(normalExpoDiff, xyCenter, 0);
-    result = base + (expoDiff.r*weights.r + expoDiff.g*weights.g + expoDiff.b*weights.b + expoDiff.a*weights.a)/(weights.r + weights.g + weights.b + weights.a);
-    result = clamp(result,0.0,1.0);
+    // How are we going to blend these two? The detail is pre-filtered to strip
+    // the even/odd phase pattern before it is weighted and added.
+    vec4 expoDiff = fetchDiffSmooth(normalExpoDiff, xyCenter);
+    float detail = (expoDiff.r*weights.r + expoDiff.g*weights.g +
+            expoDiff.b*weights.b + expoDiff.a*weights.a) /
+            max(weights.r + weights.g + weights.b + weights.a, EPS);
+    float resultVal = base + detail * blendMpy;
+    if (useUpsampled) {
+        // Keep the reconstruction inside the local base range so the pyramid
+        // cannot synthesize bright/dark rings around strong light sources:
+        // excursions above the neighborhood max or below the neighborhood min
+        // are clipped instead of being added as a halo. Neighbor taps are
+        // clamped explicitly because texture wrap state is not guaranteed.
+        vec2 texSize = vec2(textureSize(upsampled, 0));
+        vec2 d = vec2(1.0) / texSize;
+        vec2 n0 = clamp(upCoord + vec2(-d.x, 0.0), vec2(0.0), vec2(1.0));
+        vec2 n1 = clamp(upCoord + vec2(d.x, 0.0), vec2(0.0), vec2(1.0));
+        vec2 n2 = clamp(upCoord + vec2(0.0, -d.y), vec2(0.0), vec2(1.0));
+        vec2 n3 = clamp(upCoord + vec2(0.0, d.y), vec2(0.0), vec2(1.0));
+        float lo = min(base, min(min(texture(upsampled, n0).r, texture(upsampled, n1).r),
+                                 min(texture(upsampled, n2).r, texture(upsampled, n3).r)));
+        float hi = max(base, max(max(texture(upsampled, n0).r, texture(upsampled, n1).r),
+                                 max(texture(upsampled, n2).r, texture(upsampled, n3).r)));
+        resultVal = clamp(resultVal, lo, hi);
+    }
+    result = clamp(resultVal, 0.0, 1.0);
     //if(level == 0){
     //    result = result*result;
     //}

--- a/app/src/main/assets/shaders/ltm/fusionmap.glsl
+++ b/app/src/main/assets/shaders/ltm/fusionmap.glsl
@@ -1,13 +1,22 @@
 precision highp sampler2D;
 precision highp float;
-uniform sampler2D InputBuffer;
-uniform sampler2D BrBuffer;
-uniform float factor;
-out vec2 result;
+uniform sampler2D InputBuffer;   // low-res fused LTM result
+uniform sampler2D BrBuffer;      // low-res base brightness (clean guide)
+uniform float factor;            // legacy, unused (kept so setVar("factor", ...) stays valid)
 uniform int yOffset;
+out vec2 result;
 #define DH (0.0)
 #define FUSIONGAIN 1.0
 #define NORM 64.0
+// Ceiling on the LTM gain carried by the map. The same bound is re-applied to
+// the upsampled gain in initial.glsl.
+#define FUSIONCAP 8.0
+// Range gate for the edge-aware smoothing, in BrBuffer units. Must sit above
+// the base's own noise/ripple (so flat regions average freely and the pattern
+// dies) and below genuine edge steps (so the gain edge is not bled across).
+// Typical edge steps in BrBuffer are ~0.1; if the pattern survives, raise it
+// slightly, if an edge looks soft, lower it.
+#define RANGESIGMA 0.06
 #define luminocity(x) dot(x.rgb, vec3(0.299, 0.587, 0.114))
 float gammaInverse(float x) {
     return x*x;
@@ -20,21 +29,68 @@ vec4 reinhard_extended(vec4 v, float max_white) {
 
 void main() {
     ivec2 xy = ivec2(gl_FragCoord.xy);
-    xy+=ivec2(0,yOffset);
+    xy += ivec2(0, yOffset);
     ivec2 inputSize = textureSize(InputBuffer, 0);
     ivec2 safePos = clamp(xy, ivec2(0), inputSize - ivec2(1));
-    // The per-pixel gain ratio fused/base. Bounded in very dark regions where
-    // base->0 and the raw quotient explodes; the full-resolution guided filter
-    // in initial.glsl re-fits a local linear model against the luma guide, so
-    // the map only needs to carry the bounded gain, not affine coefficients.
-    float fusedValue = max(texelFetch(InputBuffer, safePos, 0).r, 0.0);
-    float baseValue = max(texelFetch(BrBuffer, safePos, 0).r, 0.0);
-    float ratio = fusedValue / max(baseValue, 0.0001);
-    // The ratio is not reliable when the base is near black. Return the
-    // neutral gain there and transition smoothly into the measured ratio as
-    // the denominator becomes informative, avoiding additive-offset bias.
-    float ratioConfidence = smoothstep(0.001, 0.01, baseValue);
-    float lowresVal  = mix(1.0, ratio, ratioConfidence);
 
-    result = vec2(lowresVal, 0.0);
+    float centerBase = max(texelFetch(BrBuffer, safePos, 0).r, 0.0);
+
+    // Edge-aware (bilateral) smoothing of the per-texel fused/base ratio, with
+    // the anti-cascade notch spatial kernel [1,2,2,2,2,2,2,2,1]/16.
+    //
+    // The fused buffer carries the pyramid's even/odd upsampling phase pattern
+    // with amplitude proportional to local edge contrast, so the ratio needs
+    // smoothing precisely at hard transitions — exactly where a Gaussian also
+    // spreads the gain edge itself (the halo, and the grid inside it). The
+    // notch kernel is [1,2,1] x [1,0,1] x [1,0,0,0,1], so its frequency
+    // response has exact zeros at f = 1/2 (Nyquist), f = 1/4 (2-texel period)
+    // and f = 1/8 (4-texel period) — precisely the frequencies at which the
+    // pyramid's 2x upsampling stages inject their even/odd phase patterns.
+    // A Gaussian has no nulls and can only trade pattern suppression against
+    // kernel width (ever-larger sigmas shrink the grid while growing the
+    // halo); the notch removes the pattern outright.
+    //
+    // A pure spatial notch spreads the gain edge across its whole support
+    // (that halo). The range gate computed from the CLEAN base brightness
+    // rejects taps from the far side of an edge, so the gain edge is not bled
+    // across while the same-side taps still see the full notch and null the
+    // pattern. Because the gate is driven by the smooth base rather than the
+    // patterned ratio, the pattern cannot fragment the gate — the failure
+    // mode that makes range filters useless on checkerboard does not apply.
+    float ratioSum = 0.0;
+    float ws = 0.0;
+    const float rangeSigmaSq2 = 2.0 * RANGESIGMA * RANGESIGMA;
+    for (int i = -4; i <= 4; i++) {
+        float wi = (abs(i) == 4) ? 1.0 : 2.0;
+        for (int j = -4; j <= 4; j++) {
+            ivec2 pos = clamp(xy + ivec2(i, j), ivec2(0), inputSize - ivec2(1));
+            float fusedValue = max(texelFetch(InputBuffer, pos, 0).r, 0.0);
+            float baseValue  = max(texelFetch(BrBuffer, pos, 0).r, 0.0);
+            float ratio = fusedValue / max(baseValue, 0.0001);
+            // The ratio is unreliable when the base is near black: blend toward
+            // the neutral gain as the denominator becomes uninformative.
+            float ratioConfidence = smoothstep(0.001, 0.01, baseValue);
+            float gain = clamp(mix(1.0, ratio, ratioConfidence), 0.0, FUSIONCAP);
+            float spatialWeight = wi * ((abs(j) == 4) ? 1.0 : 2.0);
+            float baseDelta = baseValue - centerBase;
+            float rangeWeight = exp(-(baseDelta * baseDelta) / rangeSigmaSq2);
+            float w = spatialWeight * rangeWeight;
+            ratioSum += gain * w;
+            ws += w;
+        }
+    }
+    // Re-clamp the smoothed average: the notch can overshoot slightly where
+    // the gate truncates it near an edge, and the map must stay inside its
+    // legal gain range before the full-res application.
+    float lowresVal  = clamp(ratioSum / max(ws, 1e-6), 0.0, FUSIONCAP);
+    // Dark-base gain cap: in deep shadows the fused/base ratio is dominated
+    // by the long-exposure lift, and applying it multiplies the shadow noise
+    // floor by the same factor. Limit the lift where the base is dark and
+    // release it smoothly into the midtones, where the signal can afford it.
+    // Applied to the smoothed map, so the cap cannot introduce spatial
+    // structure of its own.
+    float darkCap = mix(1.5, FUSIONCAP, smoothstep(0.04, 0.20, centerBase));
+    lowresVal = min(lowresVal, darkCap);
+    // /FUSIONGAIN so the *FUSIONGAIN in initial.glsl recovers the true gain.
+    result = vec2(lowresVal / FUSIONGAIN, 0.0);
 }

--- a/app/src/main/assets/shaders/utils/import_interpolation.glsl
+++ b/app/src/main/assets/shaders/utils/import_interpolation.glsl
@@ -114,10 +114,12 @@ vec4 textureBicubicHardware(sampler2D sampler, vec2 texCoords){
     vec4 s = vec4(xcubic.xz + xcubic.yw, ycubic.xz + ycubic.yw);
     vec4 offset = c + vec4 (xcubic.yw, ycubic.yw) / s;
     offset *= invTexSize.xxyy;
-    vec4 sample0 = texture(sampler, offset.xz);
-    vec4 sample1 = texture(sampler, offset.yz);
-    vec4 sample2 = texture(sampler, offset.xw);
-    vec4 sample3 = texture(sampler, offset.yw);
+    // Bicubic taps extend beyond the image at the border. Clamp each tap
+    // explicitly because texture wrap state is not guaranteed by callers.
+    vec4 sample0 = texture(sampler, clamp(offset.xz, vec2(0.0), vec2(1.0)));
+    vec4 sample1 = texture(sampler, clamp(offset.yz, vec2(0.0), vec2(1.0)));
+    vec4 sample2 = texture(sampler, clamp(offset.xw, vec2(0.0), vec2(1.0)));
+    vec4 sample3 = texture(sampler, clamp(offset.yw, vec2(0.0), vec2(1.0)));
     float sx = s.x / (s.x + s.y);
     float sy = s.z / (s.z + s.w);
     return mix(

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/GLTexture.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/GLTexture.java
@@ -26,6 +26,9 @@ public class GLTexture implements AutoCloseable {
     public final GLFormat mFormat;
     private static boolean[] ids = new boolean[256];
     private static int[] textures = new int[256];
+    private static GLTexture[] owners = new GLTexture[256];
+    private int trackingSlot = -1;
+    private boolean closed = false;
     public GLTexture(GLTexture in,GLFormat format) {
         this(in.mSize,new GLFormat(format),null,in.mFormat.filter,in.mFormat.wrap,0);
     }
@@ -78,21 +81,8 @@ public class GLTexture implements AutoCloseable {
         int[] TexID = new int[1];
         glGenTextures(1,TexID,0);
         Log.d("GLTexture","TexID:"+TexID[0] + " Size:"+mSize.x+"x"+mSize.y + " Format:"+mFormat.getGLFormatInternal() + " Filter:"+textureFilter + " Wrapper:"+textureWrapper);
-        for(int i = 1; i<ids.length;i++){
-            if(!ids[i]){
-                Log.d("GLTexture","get:"+i);
-                if(count < i){
-                    count = i;
-                    //glGenTextures(1,TexID,0);
-                }
-                //TexID[0] = i;
-                textures[i] = TexID[0];
-                ids[i] = true;
-                break;
-            }
-        }
-
         mTextureID = TexID[0];
+        registerTexture();
         //Log.d("GLTexture","Size:"+size+" ID:"+mTextureID);
         glActiveTexture(GL_TEXTURE1+mTextureID);
         glBindTexture(GL_TEXTURE_2D, mTextureID);
@@ -117,20 +107,8 @@ public class GLTexture implements AutoCloseable {
         int[] TexID = new int[1];
         glGenTextures(1,TexID,0);
         Log.d("GLTexture","TexID:"+TexID[0]);
-        for(int i = 1; i<ids.length;i++){
-            if(!ids[i]){
-                Log.d("GLTexture","get:"+i);
-                if(count < i){
-                    count = i;
-                    //glGenTextures(1,TexID,0);
-                }
-                //TexID[0] = i;
-                textures[i] = TexID[0];
-                ids[i] = true;
-                break;
-            }
-        }
         mTextureID = TexID[0];
+        registerTexture();
         //Log.d("GLTexture","Size:"+size+" ID:"+mTextureID);
         glActiveTexture(GL_TEXTURE1+mTextureID);
         glBindTexture(GL_TEXTURE_2D, mTextureID);
@@ -156,6 +134,23 @@ public class GLTexture implements AutoCloseable {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mFormat.filter);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mFormat.wrap);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mFormat.wrap);
+    }
+
+    private void registerTexture() {
+        for (int i = 1; i < ids.length; i++) {
+            if (!ids[i]) {
+                trackingSlot = i;
+                textures[i] = mTextureID;
+                owners[i] = this;
+                ids[i] = true;
+                if (count < i) {
+                    count = i;
+                }
+                Log.d("GLTexture", "get:" + i);
+                return;
+            }
+        }
+        Log.e("GLTexture", "Texture tracking capacity exhausted for ID " + mTextureID);
     }
     public void Bufferize(){
         if(!isBuffered) {
@@ -236,7 +231,17 @@ public class GLTexture implements AutoCloseable {
         for(int i =0; i<ids.length;i++){
             if(ids[i]) {
                 glDeleteTextures(1,new int[]{textures[i]},0);
+                if (owners[i] != null) {
+                    if (owners[i].isBuffered) {
+                        glDeleteBuffers(1, new int[]{owners[i].mBuffer}, 0);
+                    }
+                    owners[i].closed = true;
+                    owners[i].trackingSlot = -1;
+                    owners[i].isBuffered = false;
+                }
                 ids[i] = false;
+                textures[i] = 0;
+                owners[i] = null;
             }
         }
         count = 0;
@@ -244,9 +249,21 @@ public class GLTexture implements AutoCloseable {
 
     @Override
     public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         glDeleteTextures(1,new int[]{mTextureID},0);
-        ids[mTextureID] = false;
+        if (trackingSlot >= 0 && trackingSlot < ids.length) {
+            ids[trackingSlot] = false;
+            textures[trackingSlot] = 0;
+            owners[trackingSlot] = null;
+            trackingSlot = -1;
+        }
         //Log.d("GLTexture","close ID:"+mTextureID);
-        if(isBuffered) glDeleteBuffers(1,new int[]{mBuffer},0);
+        if(isBuffered) {
+            glDeleteBuffers(1,new int[]{mBuffer},0);
+            isBuffered = false;
+        }
     }
 }

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/AutoExposure.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/AutoExposure.java
@@ -57,7 +57,12 @@
         histogram.Rc = true;
         histogram.Gc = true;
         histogram.Bc = true;
-        int[][] result = histogram.Compute(previousNode.WorkingTexture);
+        int[][] result;
+        try {
+            result = histogram.Compute(previousNode.WorkingTexture);
+        } finally {
+            histogram.close();
+        }
         int histNormR = 0;
         int histNormG = 0;
         int histNormB = 0;
@@ -79,8 +84,20 @@
         glProg.useAssetProgram("autoexposure/apply");
         glProg.setTexture("InputBuffer", previousNode.WorkingTexture);
 
+        if (cnt <= 0 || !Float.isFinite(sum) || sum <= 0.0f) {
+            Log.d(Name, "Skipping auto exposure: histogram has no positive samples");
+            WorkingTexture = previousNode.WorkingTexture;
+            glProg.closed = true;
+            return;
+        }
         float avg = sum / cnt;
         float mpy = (histSize / 256.0f) * target / avg;
+        if (!Float.isFinite(mpy) || mpy <= 0.0f) {
+            Log.d(Name, "Skipping auto exposure: invalid multiplier " + mpy);
+            WorkingTexture = previousNode.WorkingTexture;
+            glProg.closed = true;
+            return;
+        }
 
         sum = 0;
         int cnt2 = 0;
@@ -138,7 +155,19 @@
             normR += (val * (1.0f + (val / (mpy * mpy))))/(1.0f + val);
         }
         Log.d("AutoExposure", "Reinhard normalizer:" + normR + " normL:" + normL + " base Mpy:" + mpy);
+        if (!Float.isFinite(normR) || normR <= 0.0f || !Float.isFinite(normL)) {
+            Log.d(Name, "Skipping auto exposure: invalid Reinhard normalizer");
+            WorkingTexture = previousNode.WorkingTexture;
+            glProg.closed = true;
+            return;
+        }
         mpy *= normL / normR;
+        if (!Float.isFinite(mpy) || mpy <= 0.0f) {
+            Log.d(Name, "Skipping auto exposure: invalid normalized multiplier " + mpy);
+            WorkingTexture = previousNode.WorkingTexture;
+            glProg.closed = true;
+            return;
+        }
 
         whiteMax *= mpy;
         Log.d("AutoExposure", "Reinhard white max (top 0.5%): " + whiteMax);

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer2.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer2.java
@@ -425,7 +425,14 @@ public class ExposureFusionBayer2 extends Node {
 
 
         SplineInterpolator splineInterpolator = SplineInterpolator.createMonotoneCubicSpline(curveX,curveY);
-        SplineInterpolator splineInterpolatorShadows = SplineInterpolator.createMonotoneCubicSpline(curveX,curveY);
+        ArrayList<Float> shadowX = new ArrayList<>();
+        ArrayList<Float> shadowY = new ArrayList<>();
+        for (int i = 0; i < curvePointsCount; i++) {
+            shadowX.add(shadowCurveX[i]);
+            shadowY.add(shadowCurveY[i]);
+        }
+        SplineInterpolator splineInterpolatorShadows =
+                SplineInterpolator.createMonotoneCubicSpline(shadowX, shadowY);
         float[] interpolatedCurveArr = new float[1024];
         float[] interpolatedCurveShadowsArr = new float[1024];
         for(int i =0 ;i<interpolatedCurveArr.length;i++){
@@ -475,7 +482,9 @@ public class ExposureFusionBayer2 extends Node {
 
         //overexposure*=overExposeMpy;
         overexposure = Math2.mix(1.f,overexposure,overExposeMpy);
+        overexposure = Math2.mix(1.f, overexposure, overExposeMaxFusion);
         underexposure*=underExposeMpy;
+        underexposure = Math2.mix(underexposure, 1.f, underExposeMinFusion);
         overexposure = Math.min(fusionExpoHighLimit,overexposure);
         underexposure = Math.max(fusionExpoLowLimit,underexposure);
 
@@ -524,7 +533,12 @@ public class ExposureFusionBayer2 extends Node {
 
             glProg.setTexture("upsampled", upsampleWip);
             glProg.setVar("useUpsampled", 1);
-            glProg.setVar("blendMpy",1.0f+dehazing-dehazing*((float)i)/(normalExpo.laplace.length-1.f));
+            // The finest Laplacian carries the one-texel even/odd phase pattern
+            // of the pyramid upsampling; amplifying it here paints a grid on
+            // fine detail. Keep the dehazing boost only at coarser levels.
+            float blendMpy = (i == 0) ? 1.0f
+                    : 1.0f + dehazing - dehazing * ((float) i) / (normalExpo.laplace.length - 1.f);
+            glProg.setVar("blendMpy", blendMpy);
             glProg.setVar("level",i);
             glProg.setVar("upscaleIn",1.0f/normalExpo.sizes[i].x, 1.0f/normalExpo.sizes[i].y);
             glProg.setVar("gauss", gaussSize);
@@ -552,7 +566,6 @@ public class ExposureFusionBayer2 extends Node {
 
         }
         //previousNode.WorkingTexture.close();
-        normalExpo.gauss[ind].close();
         //highExpo.gauss[ind].close();
         basePipeline.main1.mSize.x = initialSize.x;
         basePipeline.main1.mSize.y = initialSize.y;

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer3.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer3.java
@@ -542,7 +542,7 @@ public class ExposureFusionBayer3 extends Node {
         //glProg.setTexture("highExpo",highExpo.gauss[ind]);
         glProg.setTexture("normalExpoDiff",normalExpo.gauss[ind]);
         //glProg.setTexture("highExpoDiff",highExpo.gauss[ind]);
-        glProg.setVar("upscaleIn",binnedFuse.mSize);
+        glProg.setVar("upscaleIn",1.0f/binnedFuse.mSize.x,1.0f/binnedFuse.mSize.y);
         glProg.setVar("blendMpy",1.f);
 
         glProg.drawBlocks(binnedFuse,normalExpo.sizes[ind]);
@@ -558,9 +558,14 @@ public class ExposureFusionBayer3 extends Node {
 
             glProg.setTexture("upsampled", upsample);
             glProg.setVar("useUpsampled", 1);
-            glProg.setVar("blendMpy",1.0f+dehazing-dehazing*((float)i)/(normalExpo.laplace.length-1.f));
+            // The finest Laplacian carries the one-texel even/odd phase pattern
+            // of the pyramid upsampling; amplifying it here paints a grid on
+            // fine detail. Keep the dehazing boost only at coarser levels.
+            float blendMpy = (i == 0) ? 1.0f
+                    : 1.0f + dehazing - dehazing * ((float) i) / (normalExpo.laplace.length - 1.f);
+            glProg.setVar("blendMpy", blendMpy);
             glProg.setVar("level",i);
-            glProg.setVar("upscaleIn",normalExpo.sizes[i]);
+            glProg.setVar("upscaleIn",1.0f/normalExpo.sizes[i].x, 1.0f/normalExpo.sizes[i].y);
             glProg.setVar("gauss", gaussSize);
             glProg.setVar("target", targetLuma);
             // We can discard the previous work in progress merge.
@@ -586,7 +591,6 @@ public class ExposureFusionBayer3 extends Node {
 
         }
         //previousNode.WorkingTexture.close();
-        normalExpo.gauss[ind].close();
         //highExpo.gauss[ind].close();
         basePipeline.main1.mSize.x = initialSize.x;
         basePipeline.main1.mSize.y = initialSize.y;

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/PostPipeline.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/PostPipeline.java
@@ -127,12 +127,19 @@ public class PostPipeline extends GLBasePipeline {
         // Inject tunable values for PostPipeline (since it doesn't extend Node)
         com.particlesdevs.photoncamera.settings.TunableInjector.inject(this);
         
-        BuildDefaultPipeline();
-        GLImage resImg = runAll();
-        Bitmap res = resImg.getBufferedImage();
-        Allocator.free(resImg.byteBuffer);
-        GLTexture.closeAll();
-        return res;
+        try {
+            BuildDefaultPipeline();
+            GLImage resImg = runAll();
+            Bitmap res;
+            try {
+                res = resImg.getBufferedImage();
+            } finally {
+                Allocator.free(resImg.byteBuffer);
+            }
+            return res;
+        } finally {
+            GLTexture.closeAll();
+        }
     }
 
     private void BuildDefaultPipeline() {

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/scripts/PyramidMerging.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/scripts/PyramidMerging.java
@@ -312,6 +312,9 @@ public class PyramidMerging extends GLOneScript {
         Point rawHalf = new Point(parameters.rawSize.x/2,parameters.rawSize.y/2);
         result = new GLTexture(raw,new GLFormat(GLFormat.DataType.UNSIGNED_16,1), null, GL_NEAREST, GL_CLAMP_TO_EDGE);
         inputBase = new GLTexture(parameters.rawSize, new GLFormat(GLFormat.DataType.UNSIGNED_16,1),images.get(0).buffer, GL_NEAREST, GL_CLAMP_TO_EDGE);
+        // The base frame's CPU buffer is copied into the inputBase texture above
+        // (synchronous upload), so it is not needed anymore and can be released.
+        images.get(0).close();
         // Pyramid diff
         baseDiff = new GLTexture(rawHalf,new GLFormat(GLFormat.DataType.FLOAT_16,4),null,GL_LINEAR,GL_CLAMP_TO_EDGE);
         baseDiffOr = new GLTexture(rawHalf,new GLFormat(GLFormat.DataType.FLOAT_16,4),null,GL_LINEAR,GL_CLAMP_TO_EDGE);
@@ -780,6 +783,10 @@ public class PyramidMerging extends GLOneScript {
             //glProg.setVar("exposure", exposure);
             //glProg.setVar("weight",  1.0f);
             glProg.computeAuto(base.mSize, 1);
+            // This frame's CPU buffer has been uploaded into inputAlter and merged
+            // into the pyramid; release it to keep the peak footprint at roughly one
+            // frame instead of N frames held for the whole merge.
+            frame.close();
         }
 
         /*


### PR DESCRIPTION
More Wronski inspired, with tweaks along the way:
 - Redesign the low-res LTM gain map in fusionmap with range gates over the clena base brightness and notch spatial kernel, eliminating upsampling artifacts while keeping gain edges on one side of transitions across synthetic exposures.

 - Apply fused/base gain at full res via guided filter, with a luminance range gate and dark/bright gain caps to remove halos around high contrast edges and avoid lifting/exacerbating shadow noise.

 - Normalize bayer planes before expo weighting and clamp expo channels to improve stability and prevent overly bright expo weights.

 - Make Laplacian contrast measures and expo fusion detail reads robust to phase patterns by clamping texel positions and pre-filtering detail with a 3x3 kernel (slightly modified after starting with Nyquist). Also restrict fine scale dehaze boosts to limit LTM strengthening dehaze-induced transition artifacts.

 - Improve texture leak protection with simple ownership tracking. Additionally, ensure we close all GLTexture resources if processing fails midway.

 - Ensure AE skips cleanly when imputs are ever incorrect, to not replace the working WorkingTexture.

 - If using PyramidMerging, release frame buffers once uploaded, to keep the footprint n+1 rather than holding all frames for entire range.

 - Fix shadow curve interpolation and expo fusion tuning by using dedicated shadow splines, improve with additional fusion tuning capabilities, and introduce scale-dependent dehazing factors. Also attempt to minimize upscaling unit differences.

TODO in the future:
 - Attempt using four or five synthetic exposures opposed to three as reference.
 - Further improve edge and halo mitigations (I have tried to avoid severe smoothing). However, it is better than untouched upstream state currently as far as haloing goes.

Assisted-by: Deepseek V4 Pro
Assisted-by: Deepseek V4 Flash
Assisted-by: Kimi K3