### PR TITLE
Implement standard AE metering modes and update camera settings UI

### DIFF
--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -415,6 +415,8 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
     public int mPreviewAEMode;
     public MeteringRectangle[] mPreviewMeteringAF;
     public MeteringRectangle[] mPreviewMeteringAE;
+    private MeteringRectangle[] mInitialMeteringAF;
+    private MeteringRectangle[] mInitialMeteringAE;
     /**
      * The {@link Size} of camera preview.
      */
@@ -1563,6 +1565,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
                         //mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
                         // Flash is automatically enabled when necessary.
                         resetPreviewAEMode();
+                        applyAeMeteringRegions(mPreviewRequestBuilder);
                         Camera2ApiAutoFix.applyPrev(mPreviewRequestBuilder);
                         VendorTagUtils.builderSessionApply(mPreviewRequestBuilder, false, useMaximumResolutionKey, physicalID);
                         //if(isZslMode()){
@@ -1572,7 +1575,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
                                 Log.d(TAG, "Failed to set LENS_SHADING_MAP_MODE_ON for ZSL mode:" + Log.getStackTraceString(e));
                             }
                         //}
-                        
+
                         // Apply dynamic OIS for preview stream
                         applyOisMode(mPreviewRequestBuilder, false);
 
@@ -1685,7 +1688,8 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
         if (isZslMode()) {
             mPreviewRequestBuilder.addTarget(mImageReaderRaw.getSurface());
         }
-        mPreviewMeteringAF = mPreviewRequestBuilder.get(CONTROL_AF_REGIONS);
+        mInitialMeteringAF = mPreviewRequestBuilder.get(CONTROL_AF_REGIONS);
+        mPreviewMeteringAF = mInitialMeteringAF;
         mPreviewAFMode = PreferenceKeys.getAfMode();
         if (mIsRecordingVideo) {
             mPreviewRequestBuilder.set(CONTROL_AF_MODE, CONTROL_AF_MODE_CONTINUOUS_VIDEO);
@@ -1694,7 +1698,8 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
                 mPreviewRequestBuilder.set(CONTROL_VIDEO_STABILIZATION_MODE, CONTROL_VIDEO_STABILIZATION_MODE_ON);
             }
         }
-        mPreviewMeteringAE = mPreviewRequestBuilder.get(CONTROL_AE_REGIONS);
+        mInitialMeteringAE = mPreviewRequestBuilder.get(CONTROL_AE_REGIONS);
+        mPreviewMeteringAE = mInitialMeteringAE;
         mPreviewAEMode = mPreviewRequestBuilder.get(CONTROL_AE_MODE);
     }
 
@@ -1807,6 +1812,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
 
             cameraEventsListener.onCaptureStillPictureStarted("CaptureStarted!");
             mMeasuredFrameCnt = 0;
+            applyAeMeteringRegions(builder);
             mImageSaver.implementation = new DebugSender(cameraEventsListener);
 
             cameraEventsListener.onBurstPrepared(null);
@@ -2077,7 +2083,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             if (mFlashed) captureBuilder.set(FLASH_MODE, FLASH_MODE_TORCH);
             Log.d(TAG, "Focus:" + focus);
             captureBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_CANCEL);
-           
+
             int[] stabilizationModes = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION);
             if (stabilizationModes != null && stabilizationModes.length > 1) {
                 Log.d(TAG, "LENS_OPTICAL_STABILIZATION_MODE");
@@ -2091,6 +2097,12 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             //setAutoFlash(captureBuilder);
             //int rotation = Interface.getGravity().getCameraRotation();//activity.getWindowManager().getDefaultDisplay().getRotation();
             captureBuilder.set(CaptureRequest.JPEG_ORIENTATION, PhotonCamera.getGravity().getCameraRotation(mSensorOrientation));
+            if (mTouchFocus != null && mTouchFocus.isTouchFocus) {
+                captureBuilder.set(CaptureRequest.CONTROL_AE_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AE_REGIONS));
+                captureBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AF_REGIONS));
+            } else {
+                applyAeMeteringRegions(captureBuilder);
+            }
             VendorTagUtils.builderSessionApply(captureBuilder, true, useMaximumResolutionKey, physicalID);
             try {
                 captureBuilder.set(CaptureRequest.STATISTICS_LENS_SHADING_MAP_MODE, CaptureRequest.STATISTICS_LENS_SHADING_MAP_MODE_ON);
@@ -2379,6 +2391,81 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
         PhotonCamera.getSettings().fpsMode = PreferenceKeys.getFpsMode();
         mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, getSelectedFpsRange());
         rebuildPreviewBuilder();
+    }
+
+    private void applyAeMeteringRegions(CaptureRequest.Builder builder) {
+        int mode = PreferenceKeys.getAeMeteringStd();
+        Log.d(TAG, "applyAeMeteringRegions mode:" + mode);
+        MeteringRectangle[] rectangles = getAEMeteringRectangles(mode);
+        if (mode == -1) {
+            rectangles = mInitialMeteringAE;
+        }
+        Integer maxAeRegions = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+        if (maxAeRegions != null && maxAeRegions > 0) {
+            builder.set(CaptureRequest.CONTROL_AE_REGIONS, rectangles);
+            if (builder == mPreviewRequestBuilder) {
+                mPreviewMeteringAE = rectangles;
+            }
+        }
+    }
+
+    private MeteringRectangle[] getAEMeteringRectangles(int mode) {
+        Rect activeArray = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+        if (activeArray == null) return null;
+
+        int width = activeArray.width();
+        int height = activeArray.height();
+
+        switch (mode) {
+            case 0: // Center Weighted
+                Integer maxRegionsObj = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+                int maxRegions = maxRegionsObj != null ? maxRegionsObj : 0;
+                if (maxRegions >= 3) {
+                    // Concentric overlapping rectangles
+                    // 1. Large Base: 70%, Weight: 200
+                    int w1 = (int) (width * 0.70);
+                    int h1 = (int) (height * 0.70);
+                    int x1 = (width - w1) / 2;
+                    int y1 = (height - h1) / 2;
+
+                    // 2. Medium Core: 45%, Weight: 300
+                    int w2 = (int) (width * 0.45);
+                    int h2 = (int) (height * 0.45);
+                    int x2 = (width - w2) / 2;
+                    int y2 = (height - h2) / 2;
+
+                    // 3. Small Center: 20%, Weight: 500
+                    int w3 = (int) (width * 0.20);
+                    int h3 = (int) (height * 0.20);
+                    int x3 = (width - w3) / 2;
+                    int y3 = (height - h3) / 2;
+
+                    return new MeteringRectangle[]{
+                            new MeteringRectangle(x1, y1, w1, h1, 200),
+                            new MeteringRectangle(x2, y2, w2, h2, 300),
+                            new MeteringRectangle(x3, y3, w3, h3, 500)
+                    };
+                } else {
+                    // Fallback: single large center rectangle (60%)
+                    int cwWidth = (int) (width * 0.60);
+                    int cwHeight = (int) (height * 0.60);
+                    int cwX = (width - cwWidth) / 2;
+                    int cwY = (height - cwHeight) / 2;
+                    return new MeteringRectangle[]{new MeteringRectangle(cwX, cwY, cwWidth, cwHeight, MeteringRectangle.METERING_WEIGHT_MAX)};
+                }
+            case 1: // Frame Average
+                // Full active array
+                return new MeteringRectangle[]{new MeteringRectangle(0, 0, width, height, MeteringRectangle.METERING_WEIGHT_MAX)};
+            case 2: // Spot Metering
+                // Approximately 2.5% of the sensor area (sqrt(0.025) ≈ 0.158)
+                int sWidth = (int) (width * 0.158);
+                int sHeight = (int) (height * 0.158);
+                int sX = (width - sWidth) / 2;
+                int sY = (height - sHeight) / 2;
+                return new MeteringRectangle[]{new MeteringRectangle(sX, sY, sWidth, sHeight, MeteringRectangle.METERING_WEIGHT_MAX)};
+            default:
+                return null;
+        }
     }
 
     public void resetPreviewAEMode() {

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -1,6 +1,7 @@
 package com.particlesdevs.photoncamera.control;
 
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CaptureRequest;
 import android.hardware.camera2.params.MeteringRectangle;
@@ -76,7 +77,13 @@ public class TouchFocus {
         }
         Point size = new Point(captureController.mImageReaderPreview.getWidth(), captureController.mImageReaderPreview.getHeight());
         Point CurUi = new Point(textureView.getWidth(),textureView.getHeight());
-        Size sizee = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+        Rect activeArray = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+        Size sizee;
+        if (activeArray != null) {
+            sizee = new Size(activeArray.width(), activeArray.height());
+        } else {
+            sizee = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+        }
         if (sizee == null) {
             sizee = new Size(size.x, size.y);
         }

--- a/app/src/main/java/com/particlesdevs/photoncamera/settings/PreferenceKeys.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/settings/PreferenceKeys.java
@@ -69,6 +69,7 @@ public class PreferenceKeys {
         settingsManager.setInitial(SCOPE_GLOBAL, Key.CAMERA_MODE, resources.getString(R.string.pref_camera_mode_default));
         settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_COUNTDOWN_TIMER, 0);
         settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_BRACKETING_MODE, 0); // Default to disable bracketing
+        settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_AE_METERING_STD, -1); // Default to Off
         settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_VIDEO_RESOLUTION, resources.getString(R.string.pref_video_resolution_default));
         settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_RAWVIDEO_DOWNSCALE_4X, false);
         settingsManager.setInitial(SCOPE_GLOBAL, Key.KEY_RAWVIDEO_WRITE_ZIP, true);
@@ -379,6 +380,14 @@ public class PreferenceKeys {
         preferenceKeys.settingsManager.set(SCOPE_GLOBAL, Key.KEY_BRACKETING_MODE, value);
     }
 
+    public static int getAeMeteringStd() {
+        return preferenceKeys.settingsManager.getInteger(SCOPE_GLOBAL, Key.KEY_AE_METERING_STD);
+    }
+
+    public static void setAeMeteringStd(int value) {
+        preferenceKeys.settingsManager.set(SCOPE_GLOBAL, Key.KEY_AE_METERING_STD, value);
+    }
+
     public static void setCameraID(String value) {
         preferenceKeys.settingsManager.set(Key.CAMERAS_PREFERENCE_FILE_NAME.mValue, Key.CAMERA_ID, value);
     }
@@ -482,6 +491,7 @@ public class PreferenceKeys {
         KEY_HIDE_GALLERY_ICON(R.string.pref_hide_gallery_icon_key),
         KEY_AF_MODE(R.string.pref_af_mode_key),
         KEY_AE_MODE(R.string.pref_ae_mode_key),
+        KEY_AE_METERING_STD(R.string.pref_ae_metering_std_key),
         KEY_BRACKETING_MODE(R.string.pref_bracketing_key),
         KEY_COUNTDOWN_TIMER(R.string.pref_countdown_timer_key),
         /**

--- a/app/src/main/java/com/particlesdevs/photoncamera/settings/SettingType.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/settings/SettingType.java
@@ -10,5 +10,5 @@ public enum SettingType {
     EIS,
     RAW,
     BATTERY_SAVER,
-    BRACKETING
+    AE_METERING_STD,
 }

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraUIController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraUIController.java
@@ -260,6 +260,10 @@ final class CameraUIController implements CameraUIEventsListener,
                         // Update HDR class to use the new bracketing mode
                         IsoExpoSelector.HDR = (Integer) value > 0;
                         break;
+                    case AE_METERING_STD:
+                        PreferenceKeys.setAeMeteringStd((Integer) value);
+                        cameraFragment.captureController.applyAeMetering();
+                        break;
 
                 }
                 cameraFragment.cameraFragmentBinding.layoutTopbar.invalidateAll();

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/viewmodel/SettingsBarEntryProvider.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/viewmodel/SettingsBarEntryProvider.java
@@ -45,6 +45,7 @@ public class SettingsBarEntryProvider extends ViewModel {
     private final SettingsBarEntryModel saveRawEntry = SettingsBarEntryModel.newEntry(R.id.saveraw_entry_layout, R.string.raw_string, SettingType.RAW);
     private final SettingsBarEntryModel batterySaverEntry = SettingsBarEntryModel.newEntry(R.id.batterysaver_entry_layout, R.string.energy_saving, SettingType.BATTERY_SAVER);
     private final SettingsBarEntryModel bracketingEntry = SettingsBarEntryModel.newEntry(R.id.bracketing_entry_layout, R.string.exposure_bracketing, SettingType.BRACKETING);
+    private final SettingsBarEntryModel aeMeteringStdEntry = SettingsBarEntryModel.newEntry(R.id.ae_metering_std_entry_layout, R.string.ae_metering_std, SettingType.AE_METERING_STD);
     private final List<SettingsBarEntryModel> allEntries = new ArrayList<>(8);
 
     public SettingsBarEntryProvider() {
@@ -58,6 +59,7 @@ public class SettingsBarEntryProvider extends ViewModel {
         allEntries.add(gridEntry);
         allEntries.add(batterySaverEntry);
         allEntries.add(bracketingEntry);
+        allEntries.add(aeMeteringStdEntry);
     }
 
     public void createEntries() {
@@ -71,6 +73,7 @@ public class SettingsBarEntryProvider extends ViewModel {
         createGridEntry();
         createBatterySaverEntry();
         createBracketingEntry();
+        createAeMeteringStdEntry();
         updateAllEntries();
     }
 
@@ -85,6 +88,7 @@ public class SettingsBarEntryProvider extends ViewModel {
         updateEntry(saveRawEntry, PreferenceKeys.isSaveRaw());
         updateEntry(batterySaverEntry, PreferenceKeys.isBatterySaverOn());
         updateEntry(bracketingEntry, PreferenceKeys.getBracketingMode());
+        updateEntry(aeMeteringStdEntry, PreferenceKeys.getAeMeteringStd());
     }
 
     public void addObserver(Observer<TopBarSettingsData<?, ?>> observer) {
@@ -175,6 +179,15 @@ public class SettingsBarEntryProvider extends ViewModel {
                 SettingsBarButtonModel.newButtonModel(R.id.grid_44_button, R.drawable.ic_grid_on, R.string.four_x4, 2, gridEntry),
                 SettingsBarButtonModel.newButtonModel(R.id.grid_gr_button, R.drawable.ic_grid_on, R.string.golden_ratio, 3, gridEntry),
                 SettingsBarButtonModel.newButtonModel(R.id.grid_dt_button, R.drawable.ic_grid_on, R.string.diag_triangle, 4, gridEntry)
+        );
+    }
+
+  private void createAeMeteringStdEntry() {
+        aeMeteringStdEntry.addSettingsBarButtonModels(
+                SettingsBarButtonModel.newButtonModel(R.id.ae_metering_std_off_button, R.drawable.ic_exposure, R.string.ae_metering_off, -1, aeMeteringStdEntry),
+                SettingsBarButtonModel.newButtonModel(R.id.ae_metering_std_center_button, R.drawable.ic_exposure, R.string.ae_metering_center, 0, aeMeteringStdEntry),
+                SettingsBarButtonModel.newButtonModel(R.id.ae_metering_std_average_button, R.drawable.ic_exposure, R.string.ae_metering_average, 1, aeMeteringStdEntry),
+                SettingsBarButtonModel.newButtonModel(R.id.ae_metering_std_spot_button, R.drawable.ic_exposure, R.string.ae_metering_spot, 2, aeMeteringStdEntry)
         );
     }
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -44,4 +44,9 @@
     <item name="bracketing_off_button" type="id"/>
     <item name="bracketing_normal_button" type="id"/>
     <item name="bracketing_high_button" type="id"/>
+    <item name="ae_metering_std_entry_layout" type="id"/>
+    <item name="ae_metering_std_off_button" type="id"/>
+    <item name="ae_metering_std_center_button" type="id"/>
+    <item name="ae_metering_std_average_button" type="id"/>
+    <item name="ae_metering_std_spot_button" type="id"/>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,14 +150,22 @@
     <string name="gallery_folders">Gallery Folders</string>
     <string name="options">Options</string>
     <string name="session_on_configure_failed">System session configuration failed try changing preview format</string>
-    
+
+  <!-- Metering mode strings -->
+    <string name="ae_metering_off">Auto</string>
+    <string name="ae_metering_center">Center Weighted</string>
+    <string name="ae_metering_average">Frame Average</string>
+    <string name="ae_metering_spot">Spot Metering</string>
+    <string name="ae_metering_std">AE Metering</string>
+    <string name="pref_ae_metering_std_key" translatable="false">pref_ae_metering_std_mode_key</string>
+
     <!-- Bracketing mode strings -->
     <string name="exposure_bracketing">Exposure Bracketing</string>
     <string name="bracketing_off">Off (1x)</string>
     <string name="bracketing_normal">Normal (1x, 4x)</string>
     <string name="bracketing_high">High (1x, 8x)</string>
     <string name="pref_bracketing_key" translatable="false">pref_bracketing_mode_key</string>
-    
+
     <!-- Video Settings -->
     <string name="video_settings">Video Settings</string>
     <string name="raw_video_settings">Raw Video Settings</string>
@@ -171,7 +179,7 @@
     <string name="video_res_4k" translatable="false">3840x2160 (4K)</string>
     <string name="video_res_fhd" translatable="false">1920x1080 (Full HD)</string>
     <string name="video_res_hd" translatable="false">1280x720 (HD)</string>
-    
+
     <!-- Storage Access Framework folder picker -->
     <string name="select_dcim_folder_hint">Select the DCIM folder for saving photos</string>
 


### PR DESCRIPTION
This PR adds standard auto-exposure metering modes and integrates them into the camera settings UI, while improving metering coordinate handling and persistence.

Changes

* Implement getAEMeteringRectangles() in CaptureController for:
    * Center Weighted
    * Frame Average
    * Spot Metering
* Use sensor active-array coordinates to calculate accurate AE metering regions.
* Apply AE metering regions to both preview and still capture requests.
* Preserve manual metering settings unless they are overridden by touch-to-focus.
* Add mInitialMeteringAF and mInitialMeteringAE to store and restore the camera’s default metering regions.
* Add the AE_METERING_STD setting to PreferenceKeys and SettingType.
* Add AE Metering controls to SettingsBarEntryProvider with:
    * Auto
    * Center
    * Average
    * Spot
* Update TouchFocus to prioritize SENSOR_INFO_ACTIVE_ARRAY_SIZE for more accurate touch-to-focus coordinate mapping.

Result

This provides proper standard AE metering controls while keeping metering behavior consistent between the preview and captured image, with more accurate sensor-coordinate mapping for touch focus.