### PR TITLE
ltm/exposebayer2: Normalize Bayer planes before expo weighting

### DIFF
--- a/app/src/main/assets/shaders/ltm/exposebayer2.glsl
+++ b/app/src/main/assets/shaders/ltm/exposebayer2.glsl
@@ -136,7 +136,9 @@ void main() {
     }
     inp /= 16.0;
     inp *= gain;
-    //inp /= neutral.rggb;
+    // Normalize the four Bayer planes before calculating exposure weights.
+    // Without this, white-point differences are interpreted as brightness.
+    inp /= max(neutral.rggb, vec4(1e-6));
     inp = clamp(inp, vec4(0.0), vec4(1.0));
     //inp = clamp(inp,vec4(0.0001),vec3(NEUTRALPOINT).rggb)/vec3(NEUTRALPOINT).rggb;
 
@@ -191,17 +193,17 @@ void main() {
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.g = clamp((br),0.0,1.0);
+    result.g = clamp(br,0.0,highLim);
     v3 = brIn(inp,mix(STRHIGH,1.0,0.5));
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.b = clamp((br),0.0,1.0);
+    result.b = clamp(br,0.0,highLim);
     v3 = brIn(inp,mix(STRHIGH,1.0,0.25));
     br = luminocity(v3);
     br = gammaEncode(br);
     //br = mix(br,gammaEncode(br),clamp(br-1.0,0.0,0.6));
-    result.a = clamp((br),0.0,1.0);
+    result.a = clamp(br,0.0,highLim);
     result /= 4.0;
     #endif
 }


### PR DESCRIPTION
The four Bayer planes are scaled by the lens-shading GainMap, but the white-point normalization was commented out, so R/Gr/Gb/B plane-gain differences were interpreted as brightness when computing the synthetic exposure weights.

Re-enable the division by neutral.rggb with a 1e-6 floor to avoid division by zero, and clamp the g/b/a expo channels to highLim instead of 1.0 to prevent overly bright expo weights.