### PR TITLE
ExposureFusionBayer2: Fix shadow spline duplicating the main curve

### DIFF
--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer2.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/opengl/postpipeline/ExposureFusionBayer2.java
@@ -433,7 +433,14 @@ public class ExposureFusionBayer2 extends Node {
 
 
         SplineInterpolator splineInterpolator = SplineInterpolator.createMonotoneCubicSpline(curveX,curveY);
-        SplineInterpolator splineInterpolatorShadows = SplineInterpolator.createMonotoneCubicSpline(curveX,curveY);
+        ArrayList<Float> shadowX = new ArrayList<>();
+        ArrayList<Float> shadowY = new ArrayList<>();
+        for (int i = 0; i < curvePointsCount; i++) {
+            shadowX.add(shadowCurveX[i]);
+            shadowY.add(shadowCurveY[i]);
+        }
+        SplineInterpolator splineInterpolatorShadows =
+                SplineInterpolator.createMonotoneCubicSpline(shadowX, shadowY);
         float[] interpolatedCurveArr = new float[1024];
         float[] interpolatedCurveShadowsArr = new float[1024];
         for(int i =0 ;i<interpolatedCurveArr.length;i++){


### PR DESCRIPTION
splineInterpolatorShadows was built from curveX/curveY, leaving the shadowCurveX/shadowCurveY tunables unused and the fusion's shadow response identical to the main curve. Build it from the shadow arrays.

The wrong shadow lift skews the fused image's tonal balance, and AE downstream compensates for that skew globally (via the histogram average and top-0.5% whiteMax), pushing exposure up and clipping highlights. With the correct shadow curve, AE sees the intended distribution and no longer sacrifices highlight headroom, improving highlight recovery.