### PR TITLE
Improve AF/AE focus control and continuous autofocus behavior

### DIFF
--- a/.artifacts/bb5db1f1-e261-4af2-8c5f-16fd7423cdba/implementation_plan.artifact.md
+++ b/.artifacts/bb5db1f1-e261-4af2-8c5f-16fd7423cdba/implementation_plan.artifact.md
@@ -1,0 +1,34 @@
+# Implementation Plan - Fix Focus Shift During Capture
+
+This plan addresses the "focus shift" issue where the focus jumps after pressing the shutter button. The fix involves ensuring consistent focus state and parameters between the viewfinder preview and the still capture sequence.
+
+## User Review Required
+
+> [!IMPORTANT]
+> The changes modify core focus locking and capture request building. While intended to stabilize focus, behavior might vary across different device drivers.
+
+## Proposed Changes
+
+### Camera Capture Logic
+
+#### [MODIFY] [CaptureController.java](file:///Users/monikamalinowska/PhotonCamera/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java)
+
+- **Fix `captureStillPicture()` focus reset**:
+    - Remove the block that incorrectly sends `CONTROL_AF_TRIGGER_CANCEL` and overrides `CONTROL_AF_MODE` to `AUTO` when the preview is in `CONTINUOUS_PICTURE` mode.
+    - Instead, ensure the `captureBuilder` inherits the focus mode and state from the preview request that was just locked.
+- **Synchronize Focus Regions**:
+    - Ensure `CONTROL_AF_REGIONS` are always carried over from `mPreviewRequestBuilder` to `captureBuilder`, not just during touch-to-focus.
+- **Restore Manual Focus Support**:
+    - Uncomment and fix the manual focus application logic. If `ParamController` has a manual focus distance set, apply `CONTROL_AF_MODE_OFF` and the specific `LENS_FOCUS_DISTANCE` to the still capture request.
+- **Clean up `unlockFocus()`**:
+    - Simplify the focus unlock sequence. Replace the erratic `CANCEL` -> `START` -> `CANCEL` triggers with a single `CONTROL_AF_TRIGGER_CANCEL` and restore the default focus mode. This will prevent the viewfinder from jumping after a picture is taken.
+- **Optimize `lockFocus()`**:
+    - Ensure that if the camera is already in a focused state (e.g., `PASSIVE_FOCUSED` or `FOCUSED_LOCKED`), the `AF_START` trigger is handled gracefully to avoid unnecessary re-scans on devices with buggy drivers.
+
+## Verification Plan
+
+### Manual Verification
+- **Touch-to-Focus Test**: Touch a near object, wait for focus lock, and press shutter. Verify the focus stays on the object in the final image and doesn't jump in the viewfinder.
+- **Manual Focus Test**: Set a specific manual focus distance, press shutter, and verify the resulting image uses that exact focus distance.
+- **Continuous AF Test**: Point the camera at different objects, let it focus naturally, and press shutter. Verify no "hunting" or jumping happens at the moment of capture.
+- **Post-Capture Stability**: Verify the viewfinder doesn't perform a distracting focus scan/jump immediately after the capture sequence finishes.

--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -1322,6 +1322,20 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             Log.w(TAG, "lockFocus(): camera not ready (builder=" + mPreviewRequestBuilder + " session=" + mCaptureSession + ")");
             return;
         }
+
+        // Check current AF state. If already locked, we can skip the trigger.
+        if (mPreviewCaptureResult != null) {
+            Integer afState = mPreviewCaptureResult.get(CaptureResult.CONTROL_AF_STATE);
+            if (afState != null && (afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED ||
+                    afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED)) {
+                Log.d(TAG, "lockFocus(): Focus already locked, skipping trigger. State: " + afState);
+                mState = STATE_WAITING_LOCK;
+                // Manually invoke process to move to next state (pre-capture/capture)
+                mCaptureCallback.onCaptureCompleted(mCaptureSession, mPreviewCaptureRequest, (TotalCaptureResult) mPreviewCaptureResult);
+                return;
+            }
+        }
+
         startTimerLocked();
         // This is how to tell the camera to lock focus.
         mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
@@ -1803,36 +1817,19 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
      */
     public void unlockFocus() {
         try {
-            // Reset the auto-focus trigger
-            //mCaptureSession.stopRepeating();
-            //mCaptureSession.abortCaptures();
+            // Reset the auto-focus trigger once
             mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
                     CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
             rebuildPreviewBuilderOneShot();
-            //mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-            //        CameraMetadata.CONTROL_AF_TRIGGER_START);
-            //rebuildPreviewBuilderOneShot();
+
             reset3Aparams();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_START);
-            rebuildPreviewBuilderOneShot();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            rebuildPreviewBuilderOneShot();
+            
+            // Restore manual parameters if any
             paramController.setupPreview();
-            /*mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            mCaptureSession.capture(mPreviewRequestBuilder.build(), mCaptureCallback,
-                    mBackgroundHandler);
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_START);
-            mCaptureSession.capture(mPreviewRequestBuilder.build(), mCaptureCallback,
-                    mBackgroundHandler);*/
-            // After this, the camera will go back to the normal state of preview.
+            
+            // Go back to normal preview state
             mState = STATE_PREVIEW;
             rebuildPreviewBuilder();
-            //mCaptureSession.setRepeatingRequest(mPreviewRequest, mCaptureCallback,
-            //        mBackgroundHandler);
         }catch(Exception e){
             Log.d(TAG, "unlockFocus:"+e);
         }
@@ -2181,45 +2178,19 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             //if (frameCount == 1) frameCount++;
             cameraEventsListener.onFrameCountSet(frameCount);
             Log.d(TAG, "HDRFact1:" + paramController.isManualMode() + " HDRFact2:" + PhotonCamera.getSettings().alignAlgorithm);
-            //IsoExpoSelector.HDR = (!manualParamModel.isManualMode()) && (PhotonCamera.getSettings().alignAlgorithm == 0);
-            //IsoExpoSelector.HDR = (PhotonCamera.getSettings().alignAlgorithm == 1);
             Log.d(TAG, "HDR:" + IsoExpoSelector.HDR);
-            Object mode = mPreviewRequestBuilder.get(CONTROL_AF_MODE);
-            if(mode != null && (int) mode != CaptureRequest.CONTROL_AF_MODE_AUTO || PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO && !PhotonCamera.getSettings().selectedMode.equals(CameraMode.RAWVIDEO)) {
-                captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
-                captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-            }
-            //captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_EDOF);
-            //if ((!(focus == 0.0 && Build.BRAND.equalsIgnoreCase("samsung")))) {
-                MeteringRectangle rectaf = new MeteringRectangle(0, 0, 0, 0, 0);
-                //captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CONTROL_AF_MODE_OFF);
-                //captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CONTROL_AF_TRIGGER_CANCEL);
-                //captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, focus);
-                /*if(!mTouchFocus.isTouchFocus)
-                    captureBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{rectaf});
-                else {
-                    captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
-                    captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-                    //captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, mFocus);
-                }
-                if (paramController.FOCUS != -1){
-                    captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-                    captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, paramController.FOCUS);
-                }*/
-            //}
-            /*
-            if(!isDualSession){
-                captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CONTROL_AF_TRIGGER_IDLE);
+
+            // Inherit AF mode and regions from preview to ensure focus consistency
+            captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AF_MODE));
+            captureBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AF_REGIONS));
+            captureBuilder.set(CaptureRequest.CONTROL_AE_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AE_REGIONS));
+
+            // Apply manual focus if set
+            if (paramController.FOCUS != -1.0f) {
                 captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-                captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, focus);
-            }*/
-
-
-
-            /*mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-            if (focus != 0.0)
-                mPreviewRequestBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, focus);
-            rebuildPreviewBuilder();*/
+                captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, paramController.FOCUS);
+                Log.d(TAG, "Applying manual focus distance: " + paramController.FOCUS);
+            }
 
             IsoExpoSelector.useTripod = PhotonCamera.getGyro().getTripod();
             if (frameCount == -1) {
@@ -2438,8 +2409,12 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
     }
 
     public void reset3Aparams() {
-        setAEMode(mPreviewRequestBuilder, PreferenceKeys.getAeMode());
-        setAFMode(mPreviewRequestBuilder, PreferenceKeys.getAfMode());
+        if (mPreviewRequestBuilder != null) {
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+            setAEMode(mPreviewRequestBuilder, PreferenceKeys.getAeMode());
+            setAFMode(mPreviewRequestBuilder, PreferenceKeys.getAfMode());
+        }
         rebuildPreviewBuilder();
     }
 
@@ -2800,8 +2775,9 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
 
     public static class CameraProperties {
         private final Float minFocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_MINIMUM_FOCUS_DISTANCE);
-        private final Float maxFocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
-        public Range<Float> focusRange = (!(minFocal == null || maxFocal == null || minFocal == 0.0f)) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
+        private final Float hyperfocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
+        private final Float maxFocal = (hyperfocal != null) ? hyperfocal : 0.0f;
+        public Range<Float> focusRange = (minFocal != null && minFocal > 0.0f) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
         public Range<Integer> isoRange = new Range<>(IsoExpoSelector.getISOLOWExt(), IsoExpoSelector.getISOHIGHExt());
         public Range<Long> expRange = new Range<>(IsoExpoSelector.getEXPLOW(), IsoExpoSelector.getEXPHIGH());
         private final float evStep = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP).floatValue();

--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -1817,25 +1817,13 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
      */
     public void unlockFocus() {
         try {
-            // Reset the auto-focus trigger once
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            rebuildPreviewBuilderOneShot();
-
             reset3Aparams();
             
             // Restore manual parameters if any
             paramController.setupPreview();
             
-            // Kickstart the continuous focus algorithm if we are in a continuous mode.
-            // This ensures the camera re-evaluates the scene immediately after capture.
-            if (mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
-                    mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
-                mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-                rebuildPreviewBuilderOneShot();
-                mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-                rebuildPreviewBuilderOneShot();
-            }
+            // Ensure the trigger is reset to IDLE for repeating requests
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
 
             // Go back to normal preview state
             mState = STATE_PREVIEW;

--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -1827,6 +1827,16 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             // Restore manual parameters if any
             paramController.setupPreview();
             
+            // Kickstart the continuous focus algorithm if we are in a continuous mode.
+            // This ensures the camera re-evaluates the scene immediately after capture.
+            if (mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
+                    mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
+                mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+                rebuildPreviewBuilderOneShot();
+                mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
+                rebuildPreviewBuilderOneShot();
+            }
+
             // Go back to normal preview state
             mState = STATE_PREVIEW;
             rebuildPreviewBuilder();

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -10,8 +10,6 @@ import android.util.Size;
 import android.view.View;
 import android.view.View.OnTouchListener;
 
-import androidx.annotation.Nullable;
-
 import com.particlesdevs.photoncamera.capture.CaptureController;
 import com.particlesdevs.photoncamera.settings.PreferenceKeys;
 import com.particlesdevs.photoncamera.ui.camera.views.FocusCircleView;
@@ -23,60 +21,114 @@ public class TouchFocus {
     private final CaptureController captureController;
     private final GLPreview textureView;
     private final View focusCircleView;
+    private final View exposureCircleView;
     private final Runnable hideFocusCircleRunnable = this::hideFocusCircleView;
     public boolean isTouchFocus = false;
-    private final OnTouchListener focusListener = (v, event) -> {
-        v.performClick();
-        resetFocusCircle();
-        setInitialAFAE();
-        return true;
+
+    private final OnTouchListener dragListener = new OnTouchListener() {
+        private float startX, startY;
+        private float initialX, initialY;
+
+        @Override
+        public boolean onTouch(View v, android.view.MotionEvent event) {
+            switch (event.getAction()) {
+                case android.view.MotionEvent.ACTION_DOWN:
+                    startX = event.getRawX();
+                    startY = event.getRawY();
+                    initialX = v.getX();
+                    initialY = v.getY();
+                    focusCircleView.removeCallbacks(hideFocusCircleRunnable);
+                    return true;
+                case android.view.MotionEvent.ACTION_MOVE:
+                    float dx = event.getRawX() - startX;
+                    float dy = event.getRawY() - startY;
+                    v.setX(initialX + dx);
+                    v.setY(initialY + dy);
+                    updateRegionsFromCircles();
+                    return true;
+                case android.view.MotionEvent.ACTION_UP:
+                    v.performClick();
+                    focusCircleView.postDelayed(hideFocusCircleRunnable, AUTO_HIDE_DELAY_MS);
+                    return true;
+            }
+            return false;
+        }
     };
 
 
-    public TouchFocus(CaptureController captureController, View focusCircle, GLPreview textureView) {
+    public TouchFocus(CaptureController captureController, View focusCircle, View exposureCircle, GLPreview textureView) {
         this.captureController = captureController;
         this.focusCircleView = focusCircle;
+        this.exposureCircleView = exposureCircle;
         this.textureView = textureView;
-        focusCircleView.setOnTouchListener(focusListener);
+        focusCircleView.setOnTouchListener(dragListener);
+        exposureCircleView.setOnTouchListener(dragListener);
         resetFocusCircle();
     }
 
     public void processTouchToFocus(float fx, float fy) {
         focusCircleView.removeCallbacks(hideFocusCircleRunnable);
-        focusCircleView.post(() -> showFocusCircle(fx, fy));
+        exposureCircleView.removeCallbacks(hideFocusCircleRunnable);
+        
+        focusCircleView.post(() -> {
+            showCircle(focusCircleView, fx, fy);
+            showCircle(exposureCircleView, fx, fy);
+        });
+        
         setFocus((int) fy, (int) fx);
         focusCircleView.postDelayed(hideFocusCircleRunnable, AUTO_HIDE_DELAY_MS);
     }
 
-    private void showFocusCircle(float fx, float fy) {
-        focusCircleView.setX(fx - focusCircleView.getMeasuredWidth() / 2.0f);
-        focusCircleView.setY(fy - focusCircleView.getMeasuredHeight() / 2.0f);
-        focusCircleView.setVisibility(View.VISIBLE);
-        focusCircleView.animate().scaleY(1.2f).scaleX(1.2f).setDuration(250)
-                .withEndAction(() -> focusCircleView.animate().scaleY(1f).scaleX(1f).setDuration(250).start())
+    private void showCircle(View view, float fx, float fy) {
+        view.setX(fx - view.getMeasuredWidth() / 2.0f);
+        view.setY(fy - view.getMeasuredHeight() / 2.0f);
+        view.setVisibility(View.VISIBLE);
+        view.setAlpha(1f);
+        view.setScaleX(1f);
+        view.setScaleY(1f);
+        view.animate().scaleY(1.2f).scaleX(1.2f).setDuration(250)
+                .withEndAction(() -> view.animate().scaleY(1f).scaleX(1f).setDuration(250).start())
                 .start();
+    }
+
+    private void updateRegionsFromCircles() {
+        float afCenterX = focusCircleView.getX() + focusCircleView.getMeasuredWidth() / 2.0f;
+        float afCenterY = focusCircleView.getY() + focusCircleView.getMeasuredHeight() / 2.0f;
+        float aeCenterX = exposureCircleView.getX() + exposureCircleView.getMeasuredWidth() / 2.0f;
+        float aeCenterY = exposureCircleView.getY() + exposureCircleView.getMeasuredHeight() / 2.0f;
+
+        MeteringRectangle afRect = calculateMeteringRectangle((int) afCenterY, (int) afCenterX);
+        MeteringRectangle aeRect = calculateMeteringRectangle((int) aeCenterY, (int) aeCenterX);
+
+        if (afRect != null && aeRect != null) {
+            triggerAutoFocus(new MeteringRectangle[]{afRect}, new MeteringRectangle[]{aeRect});
+        }
     }
 
     /**
      * Sets state of focus circle view based on AF State
      */
-    public void setState(@Nullable Integer afstate) {
+    public void setState(Integer afstate) {
         if (afstate != null) {
             ((FocusCircleView) focusCircleView).setAfState(afstate);
         }
     }
 
-    private void setInitialAFAE() {
-        captureController.reset3Aparams();
+    private void setFocus(int x, int y) {
+        MeteringRectangle rect = calculateMeteringRectangle(x, y);
+        if (rect != null) {
+            MeteringRectangle[] rects = new MeteringRectangle[]{rect};
+            triggerAutoFocus(rects, rects);
+        }
     }
 
-    private void setFocus(int x, int y) {
+    private MeteringRectangle calculateMeteringRectangle(int x, int y) {
         if (captureController.mImageReaderPreview == null) {
-            Log.w(TAG, "setFocus(): mImageReaderPreview is null, camera not ready yet");
-            return;
+            Log.w(TAG, "calculateMeteringRectangle(): mImageReaderPreview is null, camera not ready yet");
+            return null;
         }
         Point size = new Point(captureController.mImageReaderPreview.getWidth(), captureController.mImageReaderPreview.getHeight());
-        Point CurUi = new Point(textureView.getWidth(),textureView.getHeight());
+        Point CurUi = new Point(textureView.getWidth(), textureView.getHeight());
         Rect activeArray = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
         Size sizee;
         if (activeArray != null) {
@@ -91,11 +143,7 @@ public class TouchFocus {
             x = 0;
         if (y < 0)
             y = 0;
-        Log.v(TAG,"y:"+y);
-        /*if (y > CurUi.y)
-            y = CurUi.y;
-        if (x > CurUi.x)
-            x  =CurUi.x;*/
+
         //use 1/6 from the the sensor size for the focus rect
         int width_to_set = sizee.getWidth() / 8;
         float kProp = (float) CurUi.x / (float) (CurUi.y);
@@ -104,50 +152,38 @@ public class TouchFocus {
         float y_scale = (float) sizee.getHeight() / (float) CurUi.x;
         int x_to_set = (int) (x * x_scale) - width_to_set / 2;
         int y_to_set = (int) (y * y_scale) - height_to_set / 2;
-        Log.v(TAG,"y_to_set:"+y_to_set);
-        y_to_set = sizee.getHeight()-y_to_set-height_to_set;
+        y_to_set = sizee.getHeight() - y_to_set - height_to_set;
         if (x_to_set < 0)
             x_to_set = 0;
         if (y_to_set < 0)
             y_to_set = 0;
-        if (y_to_set - height_to_set > sizee.getHeight())
+        if (y_to_set + height_to_set > sizee.getHeight())
             y_to_set = sizee.getHeight() - height_to_set;
-        if (x_to_set - width_to_set > sizee.getWidth())
-            y_to_set = sizee.getWidth() - width_to_set;
+        if (x_to_set + width_to_set > sizee.getWidth())
+            x_to_set = sizee.getWidth() - width_to_set;
 
-        MeteringRectangle rect_to_set = new MeteringRectangle(x_to_set, y_to_set, width_to_set, height_to_set, MeteringRectangle.METERING_WEIGHT_MAX - 1);
-        MeteringRectangle[] rectaf = new MeteringRectangle[1];
-        Log.v(TAG, "\nInput x/y:" + x + "/" + y + "\n" +
-                "sensor size width/height to set:" + width_to_set + "/" + height_to_set + "\n" +
-                "preview/sensorsize: " + CurUi.toString() + " / " + sizee.toString() + "\n" +
-                "scale x/y:" + x_scale + "/" + y_scale + "\n" +
-                "final rect :" + rect_to_set.toString());
-        rectaf[0] = rect_to_set;
-        triggerAutoFocus(rectaf);
+        return new MeteringRectangle(x_to_set, y_to_set, width_to_set, height_to_set, MeteringRectangle.METERING_WEIGHT_MAX - 1);
     }
 
-    private void triggerAutoFocus(MeteringRectangle[] rectaf) {
-        if(CaptureController.burst) return;
+    private void triggerAutoFocus(MeteringRectangle[] rectaf, MeteringRectangle[] rectae) {
+        if (CaptureController.burst) return;
         CaptureRequest.Builder builder = captureController.mPreviewRequestBuilder;
         if (builder == null) {
             Log.w(TAG, "triggerAutoFocus(): mPreviewRequestBuilder is null");
             return;
         }
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        //builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
         captureController.rebuildPreviewBuilderOneShot();
         builder.set(CaptureRequest.CONTROL_AF_REGIONS, rectaf);
-        builder.set(CaptureRequest.CONTROL_AE_REGIONS, rectaf);
+        builder.set(CaptureRequest.CONTROL_AE_REGIONS, rectae);
         builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
         builder.set(CaptureRequest.CONTROL_AF_MODE, PreferenceKeys.getAfMode());
         builder.set(CaptureRequest.CONTROL_AE_MODE, Math.max(PreferenceKeys.getAeMode(), 1));
-        //set focus area repeating,else cam forget after one frame where it should focus
-        //trigger af start only once. cam starts focusing till its focused or failed
-        if(PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO) {
+
+        if (PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO) {
             builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
             builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
             captureController.rebuildPreviewBuilderOneShot();
-            //set focus trigger back to idle to signal cam after focusing is done to do nothing
             builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
             builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
             captureController.rebuildPreviewBuilderOneShot();
@@ -155,34 +191,16 @@ public class TouchFocus {
         captureController.rebuildPreviewBuilder();
         isTouchFocus = true;
     }
+
     private void resetAutoFocus() {
-        if(CaptureController.burst) return;
+        if (CaptureController.burst) return;
         CaptureRequest.Builder builder = captureController.mPreviewRequestBuilder;
         if (builder == null) {
-            Log.w(TAG, "triggerAutoFocus(): mPreviewRequestBuilder is null");
+            Log.w(TAG, "resetAutoFocus(): mPreviewRequestBuilder is null");
             return;
         }
         Log.d(TAG, "resetAutoFocus");
-        /*builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-        captureController.rebuildPreviewBuilderOneShot();
-        builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
-        builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
-        builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
-        builder.set(CaptureRequest.CONTROL_AE_MODE, captureController.mPreviewAEMode);
-        //set focus area repeating,else cam forget after one frame where it should focus
-        //trigger af start only once. cam starts focusing till its focused or failed
-        //builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
-        //builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
-        //captureController.rebuildPreviewBuilderOneShot();
-        //set focus trigger back to idle to signal cam after focusing is done to do nothing
-        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
-        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-        captureController.rebuildPreviewBuilderOneShot();
-        captureController.rebuildPreviewBuilder();*/
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        //builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
         builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
         builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
         builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
@@ -197,21 +215,28 @@ public class TouchFocus {
     //call when focus circle needs to be hidden immediately
     public void resetFocusCircle() {
         focusCircleView.removeCallbacks(hideFocusCircleRunnable);
+        exposureCircleView.removeCallbacks(hideFocusCircleRunnable);
         focusCircleView.post(hideFocusCircleRunnable);
+        exposureCircleView.post(hideFocusCircleRunnable);
         resetAutoFocus();
     }
 
     //Must be run on UI Thread
     private void hideFocusCircleView() {
-        if (focusCircleView.getVisibility() == View.VISIBLE) {
-            focusCircleView.animate().alpha(0f).scaleY(1.8f).scaleX(1.8f).setDuration(100)
+        hideCircle(focusCircleView);
+        hideCircle(exposureCircleView);
+    }
+
+    private void hideCircle(View view) {
+        if (view.getVisibility() == View.VISIBLE) {
+            view.animate().alpha(0f).scaleY(1.8f).scaleX(1.8f).setDuration(100)
                     .withEndAction(() -> {
-                        focusCircleView.setVisibility(View.GONE);
-                        focusCircleView.setX((float) textureView.getWidth() / 2.f);
-                        focusCircleView.setY((float) textureView.getHeight() / 2.f);
-                        focusCircleView.setScaleY(1f);
-                        focusCircleView.setScaleX(1f);
-                        focusCircleView.setAlpha(1f);
+                        view.setVisibility(View.GONE);
+                        view.setX((float) textureView.getWidth() / 2.f);
+                        view.setY((float) textureView.getHeight() / 2.f);
+                        view.setScaleY(1f);
+                        view.setScaleX(1f);
+                        view.setAlpha(1f);
                     })
                     .start();
         }

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -221,7 +221,16 @@ public class TouchFocus {
         // This ensures the camera re-evaluates the scene immediately without needing motion.
         if (captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
                 captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
-            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+            
+            // Step 1: Briefly switch mode to OFF to force a state machine reset
+            builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+            captureController.rebuildPreviewBuilderOneShot();
+            
+            // Step 2: Restore CONTINUOUS mode
+            builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
+            
+            // Step 3: Send CANCEL to unlock and start a fresh passive scan
+            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
             captureController.rebuildPreviewBuilderOneShot();
         }
 

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -17,7 +17,7 @@ import com.particlesdevs.photoncamera.ui.camera.views.viewfinder.GLPreview;
 
 public class TouchFocus {
     private static final String TAG = "TouchFocus";
-    private static final int AUTO_HIDE_DELAY_MS = 3000;
+    private static final int AUTO_HIDE_DELAY_MS = 5000;
     private final CaptureController captureController;
     private final GLPreview textureView;
     private final View focusCircleView;
@@ -219,17 +219,11 @@ public class TouchFocus {
         
         // Kickstart the continuous focus algorithm if we are returning to a continuous mode.
         // This ensures the camera re-evaluates the scene immediately without needing motion.
+        // We use START -> CANCEL to jolt the state machine into PASSIVE_SCAN.
         if (captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
                 captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
-            
-            // Step 1: Briefly switch mode to OFF to force a state machine reset
-            builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
             captureController.rebuildPreviewBuilderOneShot();
-            
-            // Step 2: Restore CONTINUOUS mode
-            builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
-            
-            // Step 3: Send CANCEL to unlock and start a fresh passive scan
             builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
             captureController.rebuildPreviewBuilderOneShot();
         }

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -172,22 +172,31 @@ public class TouchFocus {
             Log.w(TAG, "triggerAutoFocus(): mPreviewRequestBuilder is null");
             return;
         }
+        
+        // Cancel any existing AF/AE triggers
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
+        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_CANCEL);
         captureController.rebuildPreviewBuilderOneShot();
+
+        // Apply new regions
         builder.set(CaptureRequest.CONTROL_AF_REGIONS, rectaf);
         builder.set(CaptureRequest.CONTROL_AE_REGIONS, rectae);
         builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, PreferenceKeys.getAfMode());
+        
+        // Force AUTO mode to ensure an active scan happens on trigger start
+        // This fixes the issue where tap-to-focus is ignored in continuous modes
+        builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
         builder.set(CaptureRequest.CONTROL_AE_MODE, Math.max(PreferenceKeys.getAeMode(), 1));
 
-        if (PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO) {
-            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
-            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-            captureController.rebuildPreviewBuilderOneShot();
-            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
-            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
-            captureController.rebuildPreviewBuilderOneShot();
-        }
+        // Start triggers
+        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
+        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+        captureController.rebuildPreviewBuilderOneShot();
+
+        // Reset triggers to IDLE for repeating requests
+        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+        
         captureController.rebuildPreviewBuilder();
         isTouchFocus = true;
     }
@@ -201,11 +210,22 @@ public class TouchFocus {
         }
         Log.d(TAG, "resetAutoFocus");
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
+        captureController.rebuildPreviewBuilderOneShot();
+        
         builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
         builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
         builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
         builder.set(CaptureRequest.CONTROL_AE_MODE, captureController.mPreviewAEMode);
-        captureController.rebuildPreviewBuilderOneShot();
+        
+        // Kickstart the continuous focus algorithm if we are returning to a continuous mode.
+        // This ensures the camera re-evaluates the scene immediately without needing motion.
+        if (captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
+                captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
+            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+            captureController.rebuildPreviewBuilderOneShot();
+        }
+
+        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
         captureController.rebuildPreviewBuilder();
         isTouchFocus = false;
     }
@@ -225,6 +245,7 @@ public class TouchFocus {
     private void hideFocusCircleView() {
         hideCircle(focusCircleView);
         hideCircle(exposureCircleView);
+        resetAutoFocus();
     }
 
     private void hideCircle(View view) {

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -217,17 +217,6 @@ public class TouchFocus {
         builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
         builder.set(CaptureRequest.CONTROL_AE_MODE, captureController.mPreviewAEMode);
         
-        // Kickstart the continuous focus algorithm if we are returning to a continuous mode.
-        // This ensures the camera re-evaluates the scene immediately without needing motion.
-        // We use START -> CANCEL to jolt the state machine into PASSIVE_SCAN.
-        if (captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE ||
-                captureController.mPreviewAFMode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO) {
-            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-            captureController.rebuildPreviewBuilderOneShot();
-            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-            captureController.rebuildPreviewBuilderOneShot();
-        }
-
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
         captureController.rebuildPreviewBuilder();
         isTouchFocus = false;

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraFragment.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraFragment.java
@@ -371,8 +371,9 @@ public class CameraFragment extends Fragment implements BaseActivity.BackPressed
     private void initTouchFocus() {
         if (cameraFragmentBinding != null && captureController != null) {
             View focusCircle = cameraFragmentBinding.layoutViewfinder.touchFocus;
+            View exposureCircle = cameraFragmentBinding.layoutViewfinder.exposureFocus;
             textureView.post(() -> {
-                mTouchFocus = new TouchFocus(captureController,focusCircle,textureView);
+                mTouchFocus = new TouchFocus(captureController,focusCircle,exposureCircle, textureView);
                 captureController.mTouchFocus = mTouchFocus;
             });
         }
@@ -770,7 +771,7 @@ public class CameraFragment extends Fragment implements BaseActivity.BackPressed
         Intent galleryIntent = new Intent(activity, GalleryActivity.class);
         // Create gallery bundle
         galleryIntent.putExtra("CameraFragment", true);
-        
+
         startActivity(galleryIntent, null);
     }
 

--- a/app/src/main/res/layout/layout_main_viewfinder.xml
+++ b/app/src/main/res/layout/layout_main_viewfinder.xml
@@ -54,6 +54,20 @@
                     app:layout_constraintTop_toTopOf="@id/texture"
                     tools:visibility="visible"/>
 
+            <com.particlesdevs.photoncamera.ui.camera.views.FocusCircleView
+                    android:id="@+id/exposureFocus"
+                    android:layout_width="@dimen/focus_circle_size"
+                    android:layout_height="0dp"
+                    app:layout_constraintDimensionRatio="1:1"
+                    android:visibility="invisible"
+                    android:color="#FFCC00"
+                    android:thickness="1.5dp"
+                    app:layout_constraintBottom_toBottomOf="@id/texture"
+                    app:layout_constraintEnd_toEndOf="@id/texture"
+                    app:layout_constraintStart_toStartOf="@id/texture"
+                    app:layout_constraintTop_toTopOf="@id/texture"
+                    tools:visibility="visible"/>
+
             <com.particlesdevs.photoncamera.ui.camera.views.viewfinder.SurfaceViewOverViewfinder
                     android:layout_width="0dp"
                     android:layout_height="0dp"

--- a/circularbarlib/src/main/java/com/particlesdevs/photoncamera/circularbarlib/camera/CameraProperties.java
+++ b/circularbarlib/src/main/java/com/particlesdevs/photoncamera/circularbarlib/camera/CameraProperties.java
@@ -18,9 +18,9 @@ public class CameraProperties {
 
     public CameraProperties(CameraCharacteristics cameraCharacteristics) {
         this.minFocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_MINIMUM_FOCUS_DISTANCE);
-        //this.maxFocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
-        this.maxFocal = 0.0f;
-        this.focusRange = (!(minFocal == null || maxFocal == null || minFocal == 0.0f)) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
+        Float hyperfocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
+        this.maxFocal = (hyperfocal != null) ? hyperfocal : 0.0f;
+        this.focusRange = (minFocal != null && minFocal > 0.0f) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
         float evStep = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP).floatValue();
         this.isoRange = new Range<>(IsoExpoSelector.getISOLOWExt(cameraCharacteristics), IsoExpoSelector.getISOHIGHExt(cameraCharacteristics));
         this.expRange = new Range<>(IsoExpoSelector.getEXPLOW(cameraCharacteristics), IsoExpoSelector.getEXPHIGH(cameraCharacteristics));


### PR DESCRIPTION
This PR improves autofocus and auto-exposure interaction, with a focus on more predictable behavior during touch focus and capture.

Changes

Implement independent, draggable focus and exposure circles for AF/AE control.
Fix focus shifting during capture and improve AF/AE consistency.
Refine the TouchFocus AF state-machine reset for continuous-focus modes.
Simplify AF trigger logic.
Remove the manual continuous-focus kickstarting logic.
Result

These changes make touch focus and AF/AE control more consistent and predictable, particularly when switching between continuous focus modes and capturing an image.