### PR TITLE
Improve AF compatibility across different camera HAL implementations and Implement independent AF/AE metering and draggable indicators

### DIFF
--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -578,10 +578,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             mPreviewCaptureRequest = request;
             process(result);
             cameraEventsListener.onPreviewCaptureCompleted(result);
-            if(PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO && !burst && !mTouchFocus.isTouchFocus) {
-                mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-                rebuildPreviewBuilderOneShot();
-            }
+            // AF START is edge-triggered; repeating it here restarted AF every frame on some HALs.
         }
 
     };
@@ -1371,6 +1368,22 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             Log.w(TAG, "lockFocus(): camera not ready (builder=" + mPreviewRequestBuilder + " session=" + mCaptureSession + ")");
             return;
         }
+        // Tap-to-focus already produced a lock. Starting AF again here can visibly shift the lens.
+        if (mPreviewCaptureResult != null) {
+            Integer afState = mPreviewCaptureResult.get(CaptureResult.CONTROL_AF_STATE);
+            if (afState != null && (afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED
+                    || afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED)) {
+                Integer aeState = mPreviewCaptureResult.get(CaptureResult.CONTROL_AE_STATE);
+                if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED
+                        || aeState == CaptureResult.CONTROL_AE_STATE_LOCKED) {
+                    mState = STATE_PICTURE_TAKEN;
+                    captureStillPicture();
+                } else {
+                    runPreCaptureSequence();
+                }
+                return;
+            }
+        }
         startTimerLocked();
         // This is how to tell the camera to lock focus.
         mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
@@ -1378,6 +1391,10 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
         // Tell #mCaptureCallback to wait for the lock.
         mState = STATE_WAITING_LOCK;
         try {
+            // START is an event, not repeating state. Submit it once, then keep preview IDLE.
+            mCaptureSession.capture(mPreviewRequestBuilder.build(), mCaptureCallback, mBackgroundHandler);
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
+                    CameraMetadata.CONTROL_AF_TRIGGER_IDLE);
             mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(), mCaptureCallback,
                     mBackgroundHandler);
         } catch (CameraAccessException e) {
@@ -1859,31 +1876,11 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             return;
         }
         try {
-            // Reset the auto-focus trigger
-            //mCaptureSession.stopRepeating();
-            //mCaptureSession.abortCaptures();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            rebuildPreviewBuilderOneShot();
-            //mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-            //        CameraMetadata.CONTROL_AF_TRIGGER_START);
-            //rebuildPreviewBuilderOneShot();
             reset3Aparams();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_START);
-            rebuildPreviewBuilderOneShot();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            rebuildPreviewBuilderOneShot();
             paramController.setupPreview();
-            /*mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            mCaptureSession.capture(mPreviewRequestBuilder.build(), mCaptureCallback,
-                    mBackgroundHandler);
+            // Final PR #176 behavior: repeating preview requests must remain IDLE.
             mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
-                    CameraMetadata.CONTROL_AF_TRIGGER_START);
-            mCaptureSession.capture(mPreviewRequestBuilder.build(), mCaptureCallback,
-                    mBackgroundHandler);*/
+                    CameraMetadata.CONTROL_AF_TRIGGER_IDLE);
             // After this, the camera will go back to the normal state of preview.
             mState = STATE_PREVIEW;
             rebuildPreviewBuilder();
@@ -2215,9 +2212,15 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             //setAutoFlash(captureBuilder);
             //int rotation = Interface.getGravity().getCameraRotation();//activity.getWindowManager().getDefaultDisplay().getRotation();
             captureBuilder.set(CaptureRequest.JPEG_ORIENTATION, PhotonCamera.getGravity().getCameraRotation(mSensorOrientation));
-            if (mTouchFocus != null && mTouchFocus.isTouchFocus) {
-                captureBuilder.set(CaptureRequest.CONTROL_AE_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AE_REGIONS));
-                captureBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AF_REGIONS));
+            MeteringRectangle[] previewAfRegions = mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AF_REGIONS);
+            Integer maxAfRegions = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
+            if (maxAfRegions != null && maxAfRegions > 0 && previewAfRegions != null) {
+                captureBuilder.set(CaptureRequest.CONTROL_AF_REGIONS, previewAfRegions);
+            }
+            MeteringRectangle[] previewAeRegions = mPreviewRequestBuilder.get(CaptureRequest.CONTROL_AE_REGIONS);
+            Integer maxAeRegions = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+            if (maxAeRegions != null && maxAeRegions > 0 && previewAeRegions != null) {
+                captureBuilder.set(CaptureRequest.CONTROL_AE_REGIONS, previewAeRegions);
             } else {
                 applyAeMeteringRegions(captureBuilder);
             }
@@ -2240,10 +2243,14 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             //IsoExpoSelector.HDR = (!manualParamModel.isManualMode()) && (PhotonCamera.getSettings().alignAlgorithm == 0);
             //IsoExpoSelector.HDR = (PhotonCamera.getSettings().alignAlgorithm == 1);
             Log.d(TAG, "HDR:" + IsoExpoSelector.HDR);
-            Object mode = mPreviewRequestBuilder.get(CONTROL_AF_MODE);
-            if(mode != null && (int) mode != CaptureRequest.CONTROL_AF_MODE_AUTO || PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO && !PhotonCamera.getSettings().selectedMode.equals(CameraMode.RAWVIDEO)) {
-                captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
-                captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
+            Integer previewAfMode = mPreviewRequestBuilder.get(CONTROL_AF_MODE);
+            captureBuilder.set(CaptureRequest.CONTROL_AF_MODE,
+                    previewAfMode != null ? previewAfMode : PreferenceKeys.getAfMode());
+            captureBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+            if (paramController.FOCUS != -1.0f) {
+                captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+                captureBuilder.set(CaptureRequest.LENS_FOCUS_DISTANCE, paramController.FOCUS);
+                Log.d(TAG, "Applying manual focus distance: " + paramController.FOCUS);
             }
             //captureBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_EDOF);
             //if ((!(focus == 0.0 && Build.BRAND.equalsIgnoreCase("samsung")))) {
@@ -2497,8 +2504,14 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
     }
 
     public void reset3Aparams() {
-        setAEMode(mPreviewRequestBuilder, PreferenceKeys.getAeMode());
-        setAFMode(mPreviewRequestBuilder, PreferenceKeys.getAfMode());
+        if (mPreviewRequestBuilder != null) {
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER,
+                    CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                    CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+            setAEMode(mPreviewRequestBuilder, PreferenceKeys.getAeMode());
+            setAFMode(mPreviewRequestBuilder, PreferenceKeys.getAfMode());
+        }
         rebuildPreviewBuilder();
     }
 
@@ -2859,8 +2872,10 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
 
     public static class CameraProperties {
         private final Float minFocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_MINIMUM_FOCUS_DISTANCE);
-        private final Float maxFocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
-        public Range<Float> focusRange = (!(minFocal == null || maxFocal == null || minFocal == 0.0f)) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
+        private final Float hyperfocal = mCameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
+        private final Float maxFocal = hyperfocal != null ? hyperfocal : 0.0f;
+        public Range<Float> focusRange = (minFocal != null && minFocal > 0.0f)
+                ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
         public Range<Integer> isoRange = new Range<>(IsoExpoSelector.getISOLOWExt(), IsoExpoSelector.getISOHIGHExt());
         public Range<Long> expRange = new Range<>(IsoExpoSelector.getEXPLOW(), IsoExpoSelector.getEXPHIGH());
         private final float evStep = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP).floatValue();

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/Swipe.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/Swipe.java
@@ -110,8 +110,13 @@ public class Swipe {
         );
         // Interface.getCameraFragment().showToast(previewRect.toString()+"\nCurX"+event.getX()+"CurY"+event.getY());
         if (viewfinderRect.contains(event.getX(), event.getY())) {
-            float translateX = event.getX() - camera_container.getLeft();
-            float translateY = event.getY() - camera_container.getTop();
+            View texture = cameraFragment.findViewById(R.id.texture);
+            int[] holderLocation = new int[2];
+            int[] textureLocation = new int[2];
+            cameraFragment.findViewById(R.id.textureHolder).getLocationOnScreen(holderLocation);
+            texture.getLocationOnScreen(textureLocation);
+            float translateX = event.getX() + holderLocation[0] - textureLocation[0];
+            float translateY = event.getY() + holderLocation[1] - textureLocation[1];
             if (manualModeConsole.getManualParamModel().getCurrentFocusValue() == ManualParamModel.FOCUS_AUTO)
                 cameraFragment.getTouchFocus().processTouchToFocus(translateX, translateY);
         }

--- a/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/control/TouchFocus.java
@@ -5,10 +5,10 @@ import android.graphics.Rect;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CaptureRequest;
 import android.hardware.camera2.params.MeteringRectangle;
-import com.particlesdevs.photoncamera.util.Log;
+import android.os.SystemClock;
 import android.util.Size;
+import android.view.MotionEvent;
 import android.view.View;
-import android.view.View.OnTouchListener;
 
 import androidx.annotation.Nullable;
 
@@ -17,203 +17,310 @@ import com.particlesdevs.photoncamera.settings.PreferenceKeys;
 import com.particlesdevs.photoncamera.ui.camera.views.FocusCircleView;
 import com.particlesdevs.photoncamera.ui.camera.views.viewfinder.GLPreview;
 
+/** Coordinates independently movable Camera2 AF and AE metering points. */
 public class TouchFocus {
-    private static final String TAG = "TouchFocus";
-    private static final int AUTO_HIDE_DELAY_MS = 3000;
+    private static final int AUTO_HIDE_DELAY_MS = 5000;
+    private static final int DRAG_AF_TRIGGER_INTERVAL_MS = 120;
+    private enum MeteringType { AF, AE }
+
     private final CaptureController captureController;
     private final GLPreview textureView;
-    private final View focusCircleView;
-    private final Runnable hideFocusCircleRunnable = this::hideFocusCircleView;
+    private final FocusCircleView focusCircleView;
+    private final FocusCircleView exposureCircleView;
+    private final Runnable hideIndicatorsRunnable = this::hideIndicators;
+    private MeteringRectangle afRegion;
+    private MeteringRectangle aeRegion;
     public boolean isTouchFocus = false;
-    private final OnTouchListener focusListener = (v, event) -> {
-        v.performClick();
-        resetFocusCircle();
-        setInitialAFAE();
-        return true;
-    };
 
-
-    public TouchFocus(CaptureController captureController, View focusCircle, GLPreview textureView) {
+    public TouchFocus(CaptureController captureController, FocusCircleView focusCircle,
+                      FocusCircleView exposureCircle, GLPreview textureView) {
         this.captureController = captureController;
         this.focusCircleView = focusCircle;
+        this.exposureCircleView = exposureCircle;
         this.textureView = textureView;
-        focusCircleView.setOnTouchListener(focusListener);
-        resetFocusCircle();
+        exposureCircleView.setExposureIndicator(true);
+        focusCircleView.setOnTouchListener(createDragListener(MeteringType.AF));
+        exposureCircleView.setOnTouchListener(createDragListener(MeteringType.AE));
+        hideIndicatorsImmediately();
     }
 
-    public void processTouchToFocus(float fx, float fy) {
-        focusCircleView.removeCallbacks(hideFocusCircleRunnable);
-        focusCircleView.post(() -> showFocusCircle(fx, fy));
-        setFocus((int) fy, (int) fx);
-        focusCircleView.postDelayed(hideFocusCircleRunnable, AUTO_HIDE_DELAY_MS);
+    /** Both meters and controls start at the exact tapped point. */
+    public void processTouchToFocus(float x, float y) {
+        cancelAutoHide();
+        float afX = clamp(x, 0, textureView.getWidth());
+        showIndicator(focusCircleView, afX, y, true);
+        showIndicator(exposureCircleView, afX, y, true);
+        afRegion = createMeteringRectangle(afX, y);
+        aeRegion = createMeteringRectangle(afX, y);
+        applyMetering(true, true);
+        scheduleAutoHide();
     }
 
-    private void showFocusCircle(float fx, float fy) {
-        focusCircleView.setX(fx - focusCircleView.getMeasuredWidth() / 2.0f);
-        focusCircleView.setY(fy - focusCircleView.getMeasuredHeight() / 2.0f);
-        focusCircleView.setVisibility(View.VISIBLE);
-        focusCircleView.animate().scaleY(1.2f).scaleX(1.2f).setDuration(250)
-                .withEndAction(() -> focusCircleView.animate().scaleY(1f).scaleX(1f).setDuration(250).start())
-                .start();
-    }
-
-    /**
-     * Sets state of focus circle view based on AF State
-     */
-    public void setState(@Nullable Integer afstate) {
-        if (afstate != null) {
-            ((FocusCircleView) focusCircleView).setAfState(afstate);
+    public void setState(@Nullable Integer afState) {
+        if (afState != null && focusCircleView.getVisibility() == View.VISIBLE) {
+            focusCircleView.setAfState(afState);
         }
     }
 
-    private void setInitialAFAE() {
-        captureController.reset3Aparams();
+    private View.OnTouchListener createDragListener(MeteringType type) {
+        return new View.OnTouchListener() {
+            private float pointerOffsetX;
+            private float pointerOffsetY;
+            private long lastAfTriggerTime;
+
+            @Override
+            public boolean onTouch(View view, MotionEvent event) {
+                if (event.getActionMasked() == MotionEvent.ACTION_DOWN
+                        && type == MeteringType.AE) {
+                    float dx = event.getX() - view.getWidth() / 2f;
+                    float dy = event.getY() - view.getHeight() / 2f;
+                    // The inner yellow sun owns AE; the outer ring falls through to AF.
+                    if (Math.hypot(dx, dy) > view.getWidth() * 0.34f) return false;
+                }
+                float[] point = toTextureCoordinates(event);
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        view.getParent().requestDisallowInterceptTouchEvent(true);
+                        cancelAutoHide();
+                        pointerOffsetX = point[0] - indicatorCenterX(view);
+                        pointerOffsetY = point[1] - indicatorCenterY(view);
+                        return true;
+                    case MotionEvent.ACTION_MOVE:
+                        long now = SystemClock.uptimeMillis();
+                        boolean triggerWhileDragging = type == MeteringType.AF
+                                && now - lastAfTriggerTime >= DRAG_AF_TRIGGER_INTERVAL_MS;
+                        moveMeter(type, point[0] - pointerOffsetX, point[1] - pointerOffsetY,
+                                triggerWhileDragging);
+                        if (triggerWhileDragging) lastAfTriggerTime = now;
+                        return true;
+                    case MotionEvent.ACTION_UP:
+                        moveMeter(type, point[0] - pointerOffsetX, point[1] - pointerOffsetY, true);
+                        view.performClick();
+                        view.getParent().requestDisallowInterceptTouchEvent(false);
+                        scheduleAutoHide();
+                        return true;
+                    case MotionEvent.ACTION_CANCEL:
+                        view.getParent().requestDisallowInterceptTouchEvent(false);
+                        scheduleAutoHide();
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        };
     }
 
-    private void setFocus(int x, int y) {
-        if (captureController.mImageReaderPreview == null) {
-            Log.w(TAG, "setFocus(): mImageReaderPreview is null, camera not ready yet");
-            return;
-        }
-        Point size = new Point(captureController.mImageReaderPreview.getWidth(), captureController.mImageReaderPreview.getHeight());
-        Point CurUi = new Point(textureView.getWidth(),textureView.getHeight());
-        Rect activeArray = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
-        Size sizee;
-        if (activeArray != null) {
-            sizee = new Size(activeArray.width(), activeArray.height());
+    private float[] toTextureCoordinates(MotionEvent event) {
+        int[] location = new int[2];
+        textureView.getLocationOnScreen(location);
+        return new float[]{event.getRawX() - location[0], event.getRawY() - location[1]};
+    }
+
+    private void moveMeter(MeteringType type, float x, float y, boolean trigger) {
+        x = clamp(x, 0, textureView.getWidth());
+        y = clamp(y, 0, textureView.getHeight());
+        if (type == MeteringType.AF) {
+            showIndicator(focusCircleView, x, y, false);
+            afRegion = createMeteringRectangle(x, y);
+            applyMetering(trigger, false);
         } else {
-            sizee = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+            showIndicator(exposureCircleView, x, y, false);
+            aeRegion = createMeteringRectangle(x, y);
+            applyMetering(false, trigger);
         }
-        if (sizee == null) {
-            sizee = new Size(size.x, size.y);
-        }
-        if (x < 0)
-            x = 0;
-        if (y < 0)
-            y = 0;
-        Log.v(TAG,"y:"+y);
-        /*if (y > CurUi.y)
-            y = CurUi.y;
-        if (x > CurUi.x)
-            x  =CurUi.x;*/
-        //use 1/6 from the the sensor size for the focus rect
-        int width_to_set = sizee.getWidth() / 8;
-        float kProp = (float) CurUi.x / (float) (CurUi.y);
-        int height_to_set = (int) (width_to_set * kProp);
-        float x_scale = (float) sizee.getWidth() / (float) CurUi.y;
-        float y_scale = (float) sizee.getHeight() / (float) CurUi.x;
-        int x_to_set = (int) (x * x_scale) - width_to_set / 2;
-        int y_to_set = (int) (y * y_scale) - height_to_set / 2;
-        Log.v(TAG,"y_to_set:"+y_to_set);
-        y_to_set = sizee.getHeight()-y_to_set-height_to_set;
-        if (x_to_set < 0)
-            x_to_set = 0;
-        if (y_to_set < 0)
-            y_to_set = 0;
-        if (y_to_set - height_to_set > sizee.getHeight())
-            y_to_set = sizee.getHeight() - height_to_set;
-        if (x_to_set - width_to_set > sizee.getWidth())
-            y_to_set = sizee.getWidth() - width_to_set;
-
-        MeteringRectangle rect_to_set = new MeteringRectangle(x_to_set, y_to_set, width_to_set, height_to_set, MeteringRectangle.METERING_WEIGHT_MAX - 1);
-        MeteringRectangle[] rectaf = new MeteringRectangle[1];
-        Log.v(TAG, "\nInput x/y:" + x + "/" + y + "\n" +
-                "sensor size width/height to set:" + width_to_set + "/" + height_to_set + "\n" +
-                "preview/sensorsize: " + CurUi.toString() + " / " + sizee.toString() + "\n" +
-                "scale x/y:" + x_scale + "/" + y_scale + "\n" +
-                "final rect :" + rect_to_set.toString());
-        rectaf[0] = rect_to_set;
-        triggerAutoFocus(rectaf);
     }
 
-    private void triggerAutoFocus(MeteringRectangle[] rectaf) {
-        if(CaptureController.burst) return;
-        CaptureRequest.Builder builder = captureController.mPreviewRequestBuilder;
-        if (builder == null) {
-            Log.w(TAG, "triggerAutoFocus(): mPreviewRequestBuilder is null");
-            return;
+    private void showIndicator(View view, float x, float y, boolean animate) {
+        view.animate().cancel();
+        // Indicators stay INVISIBLE (not GONE), so ConstraintLayout measures both during
+        // initial layout. Their identical measured centers make the very first AF/AE tap
+        // use the same coordinate without waiting for a second layout pass.
+        positionIndicator(view, x, y);
+        view.setAlpha(1f);
+        view.setVisibility(View.VISIBLE);
+        if (animate) {
+            view.setScaleX(1.2f);
+            view.setScaleY(1.2f);
+            view.animate().scaleX(1f).scaleY(1f).setDuration(250).start();
         }
-        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        //builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-        captureController.rebuildPreviewBuilderOneShot();
-        builder.set(CaptureRequest.CONTROL_AF_REGIONS, rectaf);
-        builder.set(CaptureRequest.CONTROL_AE_REGIONS, rectaf);
-        builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, PreferenceKeys.getAfMode());
-        builder.set(CaptureRequest.CONTROL_AE_MODE, Math.max(PreferenceKeys.getAeMode(), 1));
-        //set focus area repeating,else cam forget after one frame where it should focus
-        //trigger af start only once. cam starts focusing till its focused or failed
-        if(PreferenceKeys.getAfMode() == CaptureRequest.CONTROL_AF_MODE_AUTO) {
-            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
+    }
+
+    private void positionIndicator(View view, float x, float y) {
+        float targetCenterX = textureView.getX() + x;
+        float targetCenterY = textureView.getY() + y;
+        float layoutCenterX = view.getLeft() + view.getWidth() / 2f;
+        float layoutCenterY = view.getTop() + view.getHeight() / 2f;
+        view.setTranslationX(targetCenterX - layoutCenterX);
+        view.setTranslationY(targetCenterY - layoutCenterY);
+    }
+
+    private float indicatorCenterX(View view) {
+        return view.getX() - textureView.getX() + view.getWidth() / 2f;
+    }
+
+    private float indicatorCenterY(View view) {
+        return view.getY() - textureView.getY() + view.getHeight() / 2f;
+    }
+
+    /** Maps portrait viewfinder coordinates to the app's rotated sensor preview. */
+    private MeteringRectangle createMeteringRectangle(float viewX, float viewY) {
+        if (captureController.mImageReaderPreview == null || CaptureController.mCameraCharacteristics == null
+                || textureView.getWidth() <= 0 || textureView.getHeight() <= 0) return null;
+
+        Point previewSize = new Point(captureController.mImageReaderPreview.getWidth(),
+                captureController.mImageReaderPreview.getHeight());
+        Point uiSize = new Point(textureView.getWidth(), textureView.getHeight());
+        Rect activeArray = CaptureController.mCameraCharacteristics.get(
+                CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+        Size sensorSize = activeArray != null
+                ? new Size(activeArray.width(), activeArray.height())
+                : CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+        if (sensorSize == null) sensorSize = new Size(previewSize.x, previewSize.y);
+
+        // PR #176 mapping: the rotated portrait preview passes (screenY, screenX).
+        int x = Math.max(0, Math.round(viewY));
+        int y = Math.max(0, Math.round(viewX));
+        int regionWidth = sensorSize.getWidth() / 8;
+        float uiAspect = (float) uiSize.x / uiSize.y;
+        int regionHeight = Math.max(1, (int) (regionWidth * uiAspect));
+        float xScale = (float) sensorSize.getWidth() / uiSize.y;
+        float yScale = (float) sensorSize.getHeight() / uiSize.x;
+        int left = (int) (x * xScale) - regionWidth / 2;
+        int top = (int) (y * yScale) - regionHeight / 2;
+        top = sensorSize.getHeight() - top - regionHeight;
+        left = Math.max(0, Math.min(left, sensorSize.getWidth() - regionWidth));
+        top = Math.max(0, Math.min(top, sensorSize.getHeight() - regionHeight));
+        return new MeteringRectangle(left, top, regionWidth, regionHeight,
+                MeteringRectangle.METERING_WEIGHT_MAX - 1);
+    }
+
+    private void applyMetering(boolean triggerAf, boolean triggerAe) {
+        if (CaptureController.burst) return;
+        CaptureRequest.Builder builder = captureController.mPreviewRequestBuilder;
+        if (builder == null || CaptureController.mCameraCharacteristics == null) return;
+
+        Integer maxAf = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
+        Integer maxAe = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+        boolean supportsAfRegion = maxAf != null && maxAf > 0 && afRegion != null;
+        boolean supportsAeRegion = maxAe != null && maxAe > 0 && aeRegion != null;
+
+        if (triggerAf && supportsAfRegion) {
+            // Match PR #176's AF state transition exactly:
+            // CAF/passive -> CANCEL -> AUTO + START -> ACTIVE_SCAN -> *_LOCKED.
+            // In particular, do not submit an AUTO + IDLE request between CANCEL and START;
+            // some HALs consume that request by returning to INACTIVE without scanning.
+            builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
+            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                    CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_CANCEL);
+            captureController.rebuildPreviewBuilderOneShot();
+
+            builder.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{afRegion});
+            if (supportsAeRegion) {
+                builder.set(CaptureRequest.CONTROL_AE_REGIONS, new MeteringRectangle[]{aeRegion});
+            }
+            builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
+            builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
+            builder.set(CaptureRequest.CONTROL_AE_MODE, Math.max(PreferenceKeys.getAeMode(), 1));
             builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+            if (triggerAe && supportsAeRegion) {
+                builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                        CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
+            } else {
+                builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                        CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+            }
+            isTouchFocus = true;
             captureController.rebuildPreviewBuilderOneShot();
-            //set focus trigger back to idle to signal cam after focusing is done to do nothing
-            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+
+            // START is edge-triggered. Keep AUTO and the tap regions in the repeating
+            // request, but return both trigger fields to IDLE exactly as PR #176 does.
             builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                    CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+        } else if (triggerAe && supportsAeRegion) {
+            builder.set(CaptureRequest.CONTROL_AE_REGIONS, new MeteringRectangle[]{aeRegion});
+            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                    CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
+            isTouchFocus = true;
             captureController.rebuildPreviewBuilderOneShot();
+            builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                    CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+        } else {
+            // Region-only updates are used between throttled drag triggers.
+            if (supportsAfRegion) {
+                builder.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{afRegion});
+            }
+            if (supportsAeRegion) {
+                builder.set(CaptureRequest.CONTROL_AE_REGIONS, new MeteringRectangle[]{aeRegion});
+            }
         }
         captureController.rebuildPreviewBuilder();
-        isTouchFocus = true;
+        isTouchFocus = isTouchFocus || supportsAfRegion || supportsAeRegion;
     }
+
     private void resetAutoFocus() {
-        if(CaptureController.burst) return;
+        if (CaptureController.burst) return;
         CaptureRequest.Builder builder = captureController.mPreviewRequestBuilder;
-        if (builder == null) {
-            Log.w(TAG, "triggerAutoFocus(): mPreviewRequestBuilder is null");
-            return;
-        }
-        Log.d(TAG, "resetAutoFocus");
-        /*builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-        captureController.rebuildPreviewBuilderOneShot();
-        builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
-        builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
-        builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
-        builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
-        builder.set(CaptureRequest.CONTROL_AE_MODE, captureController.mPreviewAEMode);
-        //set focus area repeating,else cam forget after one frame where it should focus
-        //trigger af start only once. cam starts focusing till its focused or failed
-        //builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
-        //builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
-        //captureController.rebuildPreviewBuilderOneShot();
-        //set focus trigger back to idle to signal cam after focusing is done to do nothing
-        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
-        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
-        captureController.rebuildPreviewBuilderOneShot();
-        captureController.rebuildPreviewBuilder();*/
+        if (builder == null) return;
         builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_CANCEL);
-        //builder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-        builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
-        builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
+        captureController.rebuildPreviewBuilderOneShot();
+        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+        builder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE);
+        Integer maxAf = CaptureController.mCameraCharacteristics == null ? null
+                : CaptureController.mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
+        Integer maxAe = CaptureController.mCameraCharacteristics == null ? null
+                : CaptureController.mCameraCharacteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+        if (maxAf != null && maxAf > 0) {
+            builder.set(CaptureRequest.CONTROL_AF_REGIONS, captureController.mPreviewMeteringAF);
+        }
+        if (maxAe != null && maxAe > 0) {
+            builder.set(CaptureRequest.CONTROL_AE_REGIONS, captureController.mPreviewMeteringAE);
+        }
         builder.set(CaptureRequest.CONTROL_AF_MODE, captureController.mPreviewAFMode);
         builder.set(CaptureRequest.CONTROL_AE_MODE, captureController.mPreviewAEMode);
-        captureController.rebuildPreviewBuilderOneShot();
         captureController.rebuildPreviewBuilder();
+        afRegion = null;
+        aeRegion = null;
         isTouchFocus = false;
     }
 
-
-    //Thread safe
-    //call when focus circle needs to be hidden immediately
     public void resetFocusCircle() {
-        focusCircleView.removeCallbacks(hideFocusCircleRunnable);
-        focusCircleView.post(hideFocusCircleRunnable);
+        cancelAutoHide();
+        focusCircleView.post(this::hideIndicatorsImmediately);
         resetAutoFocus();
     }
 
-    //Must be run on UI Thread
-    private void hideFocusCircleView() {
-        if (focusCircleView.getVisibility() == View.VISIBLE) {
-            focusCircleView.animate().alpha(0f).scaleY(1.8f).scaleX(1.8f).setDuration(100)
-                    .withEndAction(() -> {
-                        focusCircleView.setVisibility(View.GONE);
-                        focusCircleView.setX((float) textureView.getWidth() / 2.f);
-                        focusCircleView.setY((float) textureView.getHeight() / 2.f);
-                        focusCircleView.setScaleY(1f);
-                        focusCircleView.setScaleX(1f);
-                        focusCircleView.setAlpha(1f);
-                    })
-                    .start();
-        }
+    private void scheduleAutoHide() { focusCircleView.postDelayed(hideIndicatorsRunnable, AUTO_HIDE_DELAY_MS); }
+    private void cancelAutoHide() { focusCircleView.removeCallbacks(hideIndicatorsRunnable); }
+
+    private void hideIndicators() {
+        hideIndicator(focusCircleView);
+        hideIndicator(exposureCircleView);
+        if (isTouchFocus) resetAutoFocus();
+    }
+
+    private void hideIndicator(View view) {
+        if (view.getVisibility() != View.VISIBLE) return;
+        view.animate().alpha(0f).scaleX(1.4f).scaleY(1.4f).setDuration(120)
+                .withEndAction(() -> {
+                    // INVISIBLE preserves the measured size/position for the first tap after
+                    // launch, camera resume, or an auto-hide.
+                    view.setVisibility(View.INVISIBLE);
+                    view.setAlpha(1f);
+                    view.setScaleX(1f);
+                    view.setScaleY(1f);
+                }).start();
+    }
+
+    private void hideIndicatorsImmediately() {
+        focusCircleView.animate().cancel();
+        exposureCircleView.animate().cancel();
+        focusCircleView.setVisibility(View.INVISIBLE);
+        exposureCircleView.setVisibility(View.INVISIBLE);
+    }
+
+    private static float clamp(float value, float min, float max) {
+        return Math.max(min, Math.min(value, max));
     }
 }

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraFragment.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/CameraFragment.java
@@ -88,6 +88,7 @@ import com.particlesdevs.photoncamera.settings.PreferenceKeys;
 import com.particlesdevs.photoncamera.settings.SettingsManager;
 import com.particlesdevs.photoncamera.ui.camera.binding.CustomBinding;
 import com.particlesdevs.photoncamera.ui.camera.data.CameraLensData;
+import com.particlesdevs.photoncamera.ui.camera.views.FocusCircleView;
 import com.particlesdevs.photoncamera.ui.camera.viewmodel.*;
 import com.particlesdevs.photoncamera.ui.camera.views.viewfinder.GLPreview;
 import com.particlesdevs.photoncamera.ui.camera.views.viewfinder.SurfaceViewOverViewfinder;
@@ -369,9 +370,10 @@ public class CameraFragment extends Fragment implements BaseActivity.BackPressed
 
     private void initTouchFocus() {
         if (cameraFragmentBinding != null && captureController != null) {
-            View focusCircle = cameraFragmentBinding.layoutViewfinder.touchFocus;
+            FocusCircleView focusCircle = cameraFragmentBinding.layoutViewfinder.touchFocus;
+            FocusCircleView exposureCircle = cameraFragmentBinding.layoutViewfinder.touchExposure;
             textureView.post(() -> {
-                mTouchFocus = new TouchFocus(captureController,focusCircle,textureView);
+                mTouchFocus = new TouchFocus(captureController, focusCircle, exposureCircle, textureView);
                 captureController.mTouchFocus = mTouchFocus;
             });
         }
@@ -660,7 +662,7 @@ public class CameraFragment extends Fragment implements BaseActivity.BackPressed
                         focusStr = modePrefix + " · FAIL";
                         break;
                     case CaptureResult.CONTROL_AF_STATE_PASSIVE_UNFOCUSED:
-                        focusStr = modePrefix + " · LOST";
+                        focusStr = modePrefix + " · RETRY";
                         break;
                     default:
                         focusStr = modePrefix;
@@ -807,10 +809,12 @@ public class CameraFragment extends Fragment implements BaseActivity.BackPressed
 
     private RectF getScreenRectFromMeteringRect(MeteringRectangle meteringRectangle) {
         if (captureController.mImageReaderPreview == null) return new RectF();
-        Size size = CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
-        if (size == null) {
-            size = new Size(captureController.mImageReaderPreview.getWidth(), captureController.mImageReaderPreview.getHeight());
-        }
+        Rect activeArray = CaptureController.mCameraCharacteristics.get(
+                CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+        Size size = activeArray != null ? new Size(activeArray.width(), activeArray.height())
+                : CaptureController.mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+        if (size == null) size = new Size(captureController.mImageReaderPreview.getWidth(),
+                captureController.mImageReaderPreview.getHeight());
         float left = (((float) meteringRectangle.getY() / size.getHeight()) * (textureView.getWidth()));
         float top = (((float) meteringRectangle.getX() / size.getWidth()) * (textureView.getHeight()));
         float width = (((float) meteringRectangle.getHeight() / size.getHeight()) * (textureView.getWidth()));

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/views/FocusCircleView.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/views/FocusCircleView.java
@@ -8,6 +8,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.view.View;
+import android.hardware.camera2.CaptureResult;
 
 import androidx.annotation.Nullable;
 
@@ -25,6 +26,7 @@ public class FocusCircleView extends View {
     private ColorStateList colorStateList;
     private boolean focused_locked;
     private boolean unfocused_locked;
+    private boolean exposureIndicator;
 
     public FocusCircleView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -45,11 +47,27 @@ public class FocusCircleView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         paint.setColor(getPaintColor());
-        canvas.drawCircle(getWidth() / 2f, getHeight() / 2f, getWidth() / 2.5f, paint);
+        if (!exposureIndicator) {
+            canvas.drawCircle(getWidth() / 2f, getHeight() / 2f, getWidth() / 2.5f, paint);
+        } else {
+            float cx = getWidth() / 2f;
+            float cy = getHeight() / 2f;
+            float inner = getWidth() / 7f;
+            float rayStart = getWidth() / 4.5f;
+            float rayEnd = getWidth() / 3.2f;
+            canvas.drawCircle(cx, cy, inner, paint);
+            for (int i = 0; i < 8; i++) {
+                double angle = i * Math.PI / 4d;
+                canvas.drawLine(cx + (float) Math.cos(angle) * rayStart,
+                        cy + (float) Math.sin(angle) * rayStart,
+                        cx + (float) Math.cos(angle) * rayEnd,
+                        cy + (float) Math.sin(angle) * rayEnd, paint);
+            }
+        }
     }
 
     private int getPaintColor() {
-        Function<int[], Integer> color = mode -> colorStateList.getColorForState(STATE_FOCUSED_LOCKED, colorStateList.getDefaultColor());
+        Function<int[], Integer> color = mode -> colorStateList.getColorForState(mode, colorStateList.getDefaultColor());
         if (focused_locked)
             return color.apply(STATE_FOCUSED_LOCKED);
         if (unfocused_locked)
@@ -61,15 +79,20 @@ public class FocusCircleView extends View {
         focused_locked = false;
         unfocused_locked = false;
         switch (afState) {
-            case 4:
+            case CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED:
                 focused_locked = true;
                 break;
-            case 5:
+            case CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED:
                 unfocused_locked = true;
                 break;
             default:
                 break;
         }
+        invalidate();
+    }
+
+    public void setExposureIndicator(boolean exposureIndicator) {
+        this.exposureIndicator = exposureIndicator;
         invalidate();
     }
 }

--- a/app/src/main/res/layout/layout_main_viewfinder.xml
+++ b/app/src/main/res/layout/layout_main_viewfinder.xml
@@ -54,6 +54,20 @@
                     app:layout_constraintTop_toTopOf="@id/texture"
                     tools:visibility="visible"/>
 
+            <com.particlesdevs.photoncamera.ui.camera.views.FocusCircleView
+                    android:id="@+id/touchExposure"
+                    android:layout_width="@dimen/focus_circle_size"
+                    android:layout_height="0dp"
+                    app:layout_constraintDimensionRatio="1:1"
+                    android:visibility="invisible"
+                    android:color="#FFFFB300"
+                    android:thickness="1.5dp"
+                    app:layout_constraintBottom_toBottomOf="@id/texture"
+                    app:layout_constraintEnd_toEndOf="@id/texture"
+                    app:layout_constraintStart_toStartOf="@id/texture"
+                    app:layout_constraintTop_toTopOf="@id/texture"
+                    tools:visibility="visible"/>
+
             <com.particlesdevs.photoncamera.ui.camera.views.viewfinder.SurfaceViewOverViewfinder
                     android:layout_width="0dp"
                     android:layout_height="0dp"

--- a/circularbarlib/src/main/java/com/particlesdevs/photoncamera/circularbarlib/camera/CameraProperties.java
+++ b/circularbarlib/src/main/java/com/particlesdevs/photoncamera/circularbarlib/camera/CameraProperties.java
@@ -18,9 +18,10 @@ public class CameraProperties {
 
     public CameraProperties(CameraCharacteristics cameraCharacteristics) {
         this.minFocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_MINIMUM_FOCUS_DISTANCE);
-        //this.maxFocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
-        this.maxFocal = 0.0f;
-        this.focusRange = (!(minFocal == null || maxFocal == null || minFocal == 0.0f)) ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
+        Float hyperfocal = cameraCharacteristics.get(CameraCharacteristics.LENS_INFO_HYPERFOCAL_DISTANCE);
+        this.maxFocal = hyperfocal != null ? hyperfocal : 0.0f;
+        this.focusRange = (minFocal != null && minFocal > 0.0f)
+                ? new Range<>(Math.min(minFocal, maxFocal), Math.max(minFocal, maxFocal)) : null;
         float evStep = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP).floatValue();
         this.isoRange = new Range<>(IsoExpoSelector.getISOLOWExt(cameraCharacteristics), IsoExpoSelector.getISOHIGHExt(cameraCharacteristics));
         this.expRange = new Range<>(IsoExpoSelector.getEXPLOW(cameraCharacteristics), IsoExpoSelector.getEXPHIGH(cameraCharacteristics));


### PR DESCRIPTION
## Summary

This PR improves the camera focus and exposure controls by separating AF and AE metering, correcting coordinate mapping, refining capture-request behavior, and improving manual-focus handling.

## Changes

- Added a separate draggable exposure indicator with a sun icon, allowing the AE metering point to be positioned independently from the autofocus indicator.
- Updated `TouchFocus` to coordinate independent AF and AE metering points.
- Refined AF/AE trigger logic in `CaptureController` to:
  - Prevent redundant AF and AE restarts.
  - Avoid unnecessary request updates.
  - Improve compatibility across different camera HAL implementations.
- Reworked viewfinder-to-sensor coordinate mapping:
  - Uses `SENSOR_INFO_ACTIVE_ARRAY_SIZE`.
  - Correctly accounts for the active sensor region.
  - Fixes inaccurate AF/AE region placement caused by incorrect view-to-sensor translation.
- Applied the selected manual focus distance to still-capture requests, ensuring captured images use the same focus setting as the preview.
- Improved focus-range and hyperfocal-distance handling in `CameraProperties`, including more reliable behavior when camera metadata is incomplete or device-specific.
- Updated AF state labels and related UI constants for clearer and more consistent focus-state reporting.

## Result

AF and AE can now be controlled independently and positioned more accurately. Manual focus is preserved during still capture, focus-distance calculations are more robust, and the updated trigger logic reduces unnecessary focus restarts while improving compatibility across devices.