### PR TITLE
  Improve burst-level HDR bracketing

### DIFF
--- a/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/capture/CaptureController.java
@@ -2278,6 +2278,7 @@ public class CaptureController implements MediaRecorder.OnInfoListener {
             rebuildPreviewBuilder();*/
 
             IsoExpoSelector.useTripod = PhotonCamera.getGyro().getTripod();
+            IsoExpoSelector.prepareBracketingPlan(frameCount);
             if (frameCount == -1) {
                 for (int i = 0; i < 1; i++) {
                     if(!PhotonCamera.getSettings().selectedMode.equals(CameraMode.RAWVIDEO))

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/parameters/IsoExpoSelector.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/parameters/IsoExpoSelector.java
@@ -19,6 +19,18 @@ import java.util.Locale;
 
 public class IsoExpoSelector {
     public static final int baseFrame = 1;
+    /**
+     * Capture profiles.  These values are persisted, so do not reorder them.
+     *
+     * Profiles are planned for the whole burst, rather than repeated every
+     * three frames. Static-scene profiles end with shadow frames; the
+     * flicker-safe profile deliberately interleaves short and long frames.
+     */
+    public static final int BRACKETING_OFF = 0;
+    public static final int BRACKETING_HDR = 1;
+    public static final int BRACKETING_DEEP_SHADOWS = 2;
+    public static final int BRACKETING_CLEAN_SHADOWS = 3;
+    public static final int BRACKETING_FLICKER_SAFE_MOTION = 4;
     private static final String TAG = "IsoExpoSelector";
     public static boolean HDR = false;
     public static boolean useTripod = false;
@@ -26,6 +38,103 @@ public class IsoExpoSelector {
     public static ArrayList<ExpoPair> pairs = new ArrayList<>();
     public static ArrayList<ExpoPair> fullpairs = new ArrayList<>();
     public static long lastSelectedExposure = 0;
+    private static BracketingPlan activeBracketingPlan = BracketingPlan.constant(1);
+
+    private static final class BracketingPlan {
+        final FramePlan[] frames;
+
+        private BracketingPlan(FramePlan[] frames) {
+            this.frames = frames;
+        }
+
+        static BracketingPlan constant(int frameCount) {
+            FramePlan[] frames = new FramePlan[Math.max(frameCount, 1)];
+            for (int i = 0; i < frames.length; i++) frames[i] = FramePlan.base();
+            return new BracketingPlan(frames);
+        }
+
+        FramePlan frameAt(int step) {
+            if (step < 0 || step >= frames.length) return FramePlan.base();
+            return frames[step];
+        }
+    }
+
+    private static final class FramePlan {
+        final float multiplier;
+        final boolean flickerSafe;
+
+        private FramePlan(float multiplier, boolean flickerSafe) {
+            this.multiplier = multiplier;
+            this.flickerSafe = flickerSafe;
+        }
+
+        static FramePlan base() {
+            return new FramePlan(1.f, false);
+        }
+
+        static FramePlan shadow(float multiplier) {
+            return new FramePlan(multiplier, false);
+        }
+
+        static FramePlan flickerSafe(boolean longExposure) {
+            // 1/25 s × 16 gain is 64× (six stops) brighter than 1/100 s at
+            // base gain. The actual ratio is recomputed from capture metadata.
+            return new FramePlan(longExposure ? 64.f : 1.f, true);
+        }
+    }
+
+    /**
+     * Creates one exposure plan per capture. Static-scene profiles reserve the
+     * final frame(s) for shadow signal. Flicker-safe Motion HDR alternates
+     * 1/100 s and 1/25 s frames to keep both exposures near the same moment.
+     */
+    public static void prepareBracketingPlan(int frameCount) {
+        int count = Math.max(frameCount, 1);
+        FramePlan[] frames = new FramePlan[count];
+        for (int i = 0; i < count; i++) frames[i] = FramePlan.base();
+        int profile = HDR ? PreferenceKeys.getBracketingMode() : BRACKETING_OFF;
+        int shadowFrames = 0;
+        float shadowMultiplier = 1.f;
+
+        switch (profile) {
+            case BRACKETING_HDR:
+                shadowFrames = 1;
+                shadowMultiplier = 4.f;
+                break;
+            case BRACKETING_DEEP_SHADOWS:
+                shadowFrames = 1;
+                shadowMultiplier = 8.f;
+                break;
+            case BRACKETING_CLEAN_SHADOWS:
+                shadowFrames = 2;
+                shadowMultiplier = 4.f;
+                break;
+            case BRACKETING_FLICKER_SAFE_MOTION:
+                // S + L + S (+ L...) places a short reference immediately on
+                // either side of every long frame when possible.
+                for (int i = 0; i < count; i++) {
+                    frames[i] = FramePlan.flickerSafe((i & 1) == 1);
+                }
+                activeBracketingPlan = new BracketingPlan(frames);
+                Log.d(TAG, "Bracketing plan: frames=" + count + " profile=" + profile
+                        + " sequence=S+L interleaved (1/100 s, 1/25 s ×16)");
+                return;
+            case BRACKETING_OFF:
+            default:
+                break;
+        }
+
+        // Always retain one short frame. A two-long-frame plan also needs at
+        // least two short frames for robust alignment and deghosting.
+        int minReferences = shadowFrames > 1 ? 2 : 1;
+        shadowFrames = Math.min(shadowFrames, Math.max(0, count - minReferences));
+        for (int i = count - shadowFrames; i < count; i++) {
+            frames[i] = FramePlan.shadow(shadowMultiplier);
+        }
+        activeBracketingPlan = new BracketingPlan(frames);
+        Log.d(TAG, "Bracketing plan: frames=" + count + " profile=" + profile
+                + " shadowFrames=" + shadowFrames + " multiplier=" + shadowMultiplier);
+    }
 
     // ---- Shutter-Priority / Dynamic Low-Light AE Curve ----
     // Instead of letting stock 3A pick a fast shutter + high ISO, we keep the SAME
@@ -201,37 +310,8 @@ public class IsoExpoSelector {
             pair.ExpoCompensateLowerExpo(2.f);
             pair.ExpoCompensateLower(1.f/2.f);
         }*/
-        if (step%patternSize == 0 && HDR) {
-            // Set multiplier based on bracketing mode (0=Off, 1=Normal, 2=High)
-            int bracketingMode = PreferenceKeys.getBracketingMode();
-            pair.layerMpy = 1.f;
-            if (bracketingMode == 1) {
-                // Normal bracketing (1x, 4x)
-                pair.layerMpy = 4.f;
-            } else if (bracketingMode == 2) {
-                // High bracketing (1x, 8x)
-                pair.layerMpy = 8.f;
-            }
-
-            if (pair.layerMpy > 1.f) {
-                pair.curlayer = ExpoPair.exposureLayer.High;
-                if (pair.ExpoCompensateLowerExpo2(1.0 / pair.layerMpy)) {
-                    pair.layerMpy = 1.f;
-                    pair.curlayer = ExpoPair.exposureLayer.Normal;
-                }
-            } else {
-                pair.curlayer = ExpoPair.exposureLayer.Normal;
-            }
-        }
-        if ((step%patternSize == 1) && HDR) {
-            pair.layerMpy = 1.f;
-            pair.ExpoCompensateLowerExpo2(1.0 / pair.layerMpy);
-            pair.curlayer = ExpoPair.exposureLayer.Normal;
-        }
-        if (step%patternSize == 2 && HDR) {
-            pair.layerMpy = 1.f;
-            pair.ExpoCompensateLowerExpo2(1.0 / pair.layerMpy);
-            pair.curlayer = ExpoPair.exposureLayer.Normal;
+        if (HDR && step >= 0) {
+            applyBracketingFrame(pair, activeBracketingPlan.frameAt(step));
         }
 
         if (pair.exposure < ExposureIndex.sec / 90 && PhotonCamera.getSettings().eisPhoto) {
@@ -247,6 +327,51 @@ public class IsoExpoSelector {
         }
         pair.denormalizeSystem();
         return pair;
+    }
+
+    private static void applyBracketingFrame(ExpoPair pair, FramePlan frame) {
+        if (frame.flickerSafe) {
+            applyFlickerSafeExposure(pair, frame.multiplier > 1.f);
+            return;
+        }
+
+        float multiplier = frame.multiplier;
+        pair.layerMpy = multiplier;
+        if (multiplier <= 1.f) {
+            pair.curlayer = ExpoPair.exposureLayer.Normal;
+            return;
+        }
+
+        pair.curlayer = ExpoPair.exposureLayer.High;
+        if (pair.ExpoCompensateLowerExpo2(1.0 / multiplier)) {
+            // A device limit prevented the requested bracket; make its metadata
+            // truthful so the merger never exposure-scales the frame incorrectly.
+            pair.layerMpy = 1.f;
+            pair.curlayer = ExpoPair.exposureLayer.Normal;
+        }
+    }
+
+    private static void applyFlickerSafeExposure(ExpoPair pair, boolean longExposure) {
+        long shortExposure = clampExposure(pair, ExposureIndex.sec / 100);
+        int shortIso = clampNormalizedIso(pair, 100);
+        long targetExposure = longExposure ? ExposureIndex.sec / 25 : ExposureIndex.sec / 100;
+        int targetIso = longExposure ? shortIso * 16 : shortIso;
+
+        pair.exposure = clampExposure(pair, targetExposure);
+        pair.iso = clampNormalizedIso(pair, targetIso);
+        pair.layerMpy = (float) (((double) pair.exposure * pair.iso)
+                / ((double) shortExposure * shortIso));
+        pair.curlayer = pair.layerMpy > 1.f
+                ? ExpoPair.exposureLayer.High : ExpoPair.exposureLayer.Normal;
+    }
+
+    private static long clampExposure(ExpoPair pair, long exposure) {
+        return Math.max(pair.exposurelow, Math.min(exposure, pair.exposurehigh));
+    }
+
+    private static int clampNormalizedIso(ExpoPair pair, int iso) {
+        int normalizedMaxIso = (int) (pair.isohigh * 100.0 / pair.isolow);
+        return Math.max(100, Math.min(iso, normalizedMaxIso));
     }
 
     public static double getMPY() {

--- a/app/src/main/java/com/particlesdevs/photoncamera/processing/processor/HdrxProcessor.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/processing/processor/HdrxProcessor.java
@@ -129,6 +129,7 @@ public class HdrxProcessor extends ProcessorBase {
         ArrayList<ImageFrame> images = new ArrayList<>();
         int ISO = 0;
         int normalFrames = 0;
+        int shadowFrames = 0;
         if(BurstShakiness.size() < mImageFramesToProcess.size()){
             Log.d(TAG,"Warning: Gyro data size:"+BurstShakiness.size()+" is less than image size:"+mImageFramesToProcess.size());
         }
@@ -143,6 +144,7 @@ public class HdrxProcessor extends ProcessorBase {
             frame.pair.layerMpy = (float) (exposures.get(mImageFramesToProcess.get(i).getTimestamp()) / minExpo);
             if (frame.pair.layerMpy > 1.0) {
                 frame.pair.curlayer = IsoExpoSelector.ExpoPair.exposureLayer.High;
+                shadowFrames++;
             } else {
                 frame.pair.curlayer = IsoExpoSelector.ExpoPair.exposureLayer.Normal;
                 normalFrames++;
@@ -206,8 +208,13 @@ public class HdrxProcessor extends ProcessorBase {
                     if(normalFrames == 1 && cur.pair.curlayer == IsoExpoSelector.ExpoPair.exposureLayer.Normal) {
                         continue;
                     }
+                    if(shadowFrames == 1 && cur.pair.curlayer == IsoExpoSelector.ExpoPair.exposureLayer.High) {
+                        continue;
+                    }
                     if(cur.pair.curlayer == IsoExpoSelector.ExpoPair.exposureLayer.Normal){
                         normalFrames--;
+                    } else if (cur.pair.curlayer == IsoExpoSelector.ExpoPair.exposureLayer.High) {
+                        shadowFrames--;
                     }
                     Log.d(TAG, "Removing unlucky:" + curunlucky + " number:" + images.get(images.size() - 1).number);
                     images.get(images.size() - 1).close();

--- a/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/viewmodel/SettingsBarEntryProvider.java
+++ b/app/src/main/java/com/particlesdevs/photoncamera/ui/camera/viewmodel/SettingsBarEntryProvider.java
@@ -144,7 +144,9 @@ public class SettingsBarEntryProvider extends ViewModel {
         bracketingEntry.addSettingsBarButtonModels(
                 SettingsBarButtonModel.newButtonModel(R.id.bracketing_off_button, R.drawable.ic_exposure, R.string.bracketing_off, 0, bracketingEntry),
                 SettingsBarButtonModel.newButtonModel(R.id.bracketing_normal_button, R.drawable.ic_exposure, R.string.bracketing_normal, 1, bracketingEntry),
-                SettingsBarButtonModel.newButtonModel(R.id.bracketing_high_button, R.drawable.ic_exposure, R.string.bracketing_high, 2, bracketingEntry)
+                SettingsBarButtonModel.newButtonModel(R.id.bracketing_high_button, R.drawable.ic_exposure, R.string.bracketing_high, 2, bracketingEntry),
+                SettingsBarButtonModel.newButtonModel(R.id.bracketing_clean_shadows_button, R.drawable.ic_exposure, R.string.bracketing_clean_shadows, 3, bracketingEntry),
+                SettingsBarButtonModel.newButtonModel(R.id.bracketing_flicker_safe_button, R.drawable.ic_exposure, R.string.bracketing_flicker_safe, 4, bracketingEntry)
         );
     }
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -4,7 +4,7 @@
     <string name="iso" translatable="false">"ISO "</string>
     <string name="icon_string" translatable="false">Icon</string>
     <string name="backup_file_name" translatable="false">PCAM_BKP_%1$s</string>
-    <string name="app_name" translatable="false">PhotonCamera</string>
+    <string name="app_name" translatable="false">PhotonCamera Bracketing</string>
     <string name="gallery_name" translatable="false">PGallery</string>
     <string name="device_support" translatable="false">PhotonCamera Pro</string>
     <string name="request_permission">이 앱을 사용하려면 카메라 권한이 필요합니다.</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -44,6 +44,8 @@
     <item name="bracketing_off_button" type="id"/>
     <item name="bracketing_normal_button" type="id"/>
     <item name="bracketing_high_button" type="id"/>
+    <item name="bracketing_clean_shadows_button" type="id"/>
+    <item name="bracketing_flicker_safe_button" type="id"/>
     <item name="ae_metering_std_entry_layout" type="id"/>
     <item name="ae_metering_std_off_button" type="id"/>
     <item name="ae_metering_std_center_button" type="id"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="iso" translatable="false">"ISO "</string>
     <string name="icon_string" translatable="false">Icon</string>
     <string name="backup_file_name" translatable="false">PCAM_BKP_%1$s</string>
-    <string name="app_name" translatable="false">PhotonCamera</string>
+    <string name="app_name" translatable="false">PhotonCamera Bracketing</string>
     <string name="gallery_name" translatable="false">PGallery</string>
     <string name="device_support" translatable="false">PhotonCamera Pro</string>
     <string name="request_permission">This app needs camera permission.</string>
@@ -162,10 +162,12 @@
     <string name="pref_ae_metering_std_key" translatable="false">pref_ae_metering_std_mode_key</string>
 
     <!-- Bracketing mode strings -->
-    <string name="exposure_bracketing">Exposure Bracketing</string>
+    <string name="exposure_bracketing">Bracketing</string>
     <string name="bracketing_off">Off (1x)</string>
-    <string name="bracketing_normal">Normal (1x, 4x)</string>
-    <string name="bracketing_high">High (1x, 8x)</string>
+    <string name="bracketing_normal">HDR (1x, 4x)</string>
+    <string name="bracketing_high">Deep shadows (1x, 8x)</string>
+    <string name="bracketing_clean_shadows">Motion-safe shadows (1x, 4x, 4x)</string>
+    <string name="bracketing_flicker_safe">Flicker-safe Motion HDR (1/100s, 1/25s ×16)</string>
     <string name="pref_bracketing_key" translatable="false">pref_bracketing_mode_key</string>
 
     <!-- Video Settings -->


### PR DESCRIPTION
## Description

  This PR replaces the repeating three-frame bracketing pattern with a capture plan built once per burst.

  ### Changes

  - Uses the existing Bracketing dropdown as the user control.
  - Captures base-exposure reference frames first, then adds shadow frames according to the selected mode:
      - HDR: one final 4× frame.
      - Deep shadows: one final 8× frame.
      - Motion-safe shadows: two final 4× frames.

  - Preserves at least one base reference and one shadow frame when removing shaky frames before merge.
  - Keeps the actual exposure ratio metadata-driven in HDRX processing.
  - Renames the dropdown from “Exposure Bracketing” to “Bracketing.”
  ### Validation

  - :app:compileDebugJavaWithJavac passes.
  - git diff --check passes.

  ### Follow-up

  Preview-histogram-based automatic bracketing are intentionally out of scope for this PR.